### PR TITLE
fix fetch data on splash

### DIFF
--- a/lib/product/init/firebase_custom_service.dart
+++ b/lib/product/init/firebase_custom_service.dart
@@ -4,5 +4,5 @@ import 'package:life_shared/life_shared.dart';
 @immutable
 final class FirebaseCustomService extends FirebaseService {
   /// getit inject
-  FirebaseCustomService() : super(timeoutDuration: const Duration(seconds: 1));
+  FirebaseCustomService() : super();
 }


### PR DESCRIPTION
timeout duration 1 saniye olarak ayarlandığı için splashte veriyi çekemiyordu. bu değeri silip default olan 10 saniyeyi kullanınca sorun yaşamadım.
fixed #71 