### PR TITLE
chore: Update "What's New" section by removing outdated features for version 8.0.0

### DIFF
--- a/lib/features/sub_feature/whats_new/whats_new_sheet.dart
+++ b/lib/features/sub_feature/whats_new/whats_new_sheet.dart
@@ -9,8 +9,6 @@ final class WhatsNewSheet extends StatelessWidget {
   const WhatsNewSheet({super.key});
 
   static const _newVersionChanges = [
-    LocaleKeys.whatsNew_features_businessHours,
-    LocaleKeys.whatsNew_features_districtInfo,
     LocaleKeys.whatsNew_features_linkPage,
     LocaleKeys.whatsNew_features_locationPinning,
     LocaleKeys.whatsNew_bugFixes,

--- a/lib/product/init/language/locale_keys.g.dart
+++ b/lib/product/init/language/locale_keys.g.dart
@@ -268,9 +268,7 @@ abstract class  LocaleKeys {
   static const chain_stores = 'chain_stores';
   static const whatsNew_title = 'whatsNew.title';
   static const whatsNew_features_linkPage = 'whatsNew.features.linkPage';
-  static const whatsNew_features_businessHours = 'whatsNew.features.businessHours';
   static const whatsNew_features_locationPinning = 'whatsNew.features.locationPinning';
-  static const whatsNew_features_districtInfo = 'whatsNew.features.districtInfo';
   static const whatsNew_features = 'whatsNew.features';
   static const whatsNew_bugFixes = 'whatsNew.bugFixes';
   static const whatsNew = 'whatsNew';


### PR DESCRIPTION
- Removed references to business hours and district info from the "What's New" section to reflect the current feature set.
- Updated locale keys to ensure consistency with the latest version changes.

Yenilikler Ekranında Çeviri Hatası #303
