### PR TITLE
chore: Update version numbers and test execution times

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -15,3 +15,4 @@ key.properties
 google_play.json
 
 /app/build
+build

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id "com.android.application"
-    id "dev.flutter.flutter-gradle-plugin"
-    id "kotlin-android"
+    id 'com.android.application'
+    id 'dev.flutter.flutter-gradle-plugin'
+    id 'kotlin-android'
 }
 
 def localProperties = new Properties()
@@ -28,10 +28,10 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace "com.hatayiyasat.appp"
-    compileSdkVersion 35
-    ndkVersion "27.0.12077973"
-
+    namespace 'com.hatayiyasat.appp'
+    compileSdkVersion 36
+    buildToolsVersion '36.0.0'
+    ndkVersion '28.0.12433566'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -4,7 +4,7 @@ default_platform(:android)
 APP_TRACK_INTERNAL = "internal"
 APP_JSON_KEY = "./fastlane/secret/google_play.json"
 APP_BUNDLE_PATH = "../build/app/outputs/bundle/release/app-release.aab"
-VERSION_NUMBER = "8.1.0"
+VERSION_NUMBER = "8.1.1"
 
 platform :android do
   lane :release do |options|

--- a/android/fastlane/report.xml
+++ b/android/fastlane/report.xml
@@ -5,27 +5,27 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000279">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000258">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: google_play_track_version_codes" time="1.825685">
+      <testcase classname="fastlane.lanes" name="1: google_play_track_version_codes" time="2.731789">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: flutter packages get" time="2.225672">
+      <testcase classname="fastlane.lanes" name="2: flutter packages get" time="1.973826">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: flutter build appbundle --build-name=8.1.1 --build-number=68" time="13.824099">
+      <testcase classname="fastlane.lanes" name="3: flutter build appbundle --build-name=8.1.1 --build-number=69" time="171.217504">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="4: upload_to_play_store" time="69.329196">
+      <testcase classname="fastlane.lanes" name="4: upload_to_play_store" time="69.648843">
         
       </testcase>
     

--- a/android/fastlane/report.xml
+++ b/android/fastlane/report.xml
@@ -5,27 +5,27 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000196">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000279">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: google_play_track_version_codes" time="2.289522">
+      <testcase classname="fastlane.lanes" name="1: google_play_track_version_codes" time="1.825685">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: flutter packages get" time="1.759109">
+      <testcase classname="fastlane.lanes" name="2: flutter packages get" time="2.225672">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: flutter build appbundle --build-name=8.1.0 --build-number=67" time="52.580589">
+      <testcase classname="fastlane.lanes" name="3: flutter build appbundle --build-name=8.1.1 --build-number=68" time="13.824099">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="4: upload_to_play_store" time="49.08555">
+      <testcase classname="fastlane.lanes" name="4: upload_to_play_store" time="69.329196">
         
       </testcase>
     

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,7 +4,6 @@ android.enableJetifier=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
-android.enableR8=true
 android.enableR8.fullMode=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,9 +1,9 @@
 pluginManagement {
     def flutterSdkPath = {
         def properties = new Properties()
-        file("local.properties").withInputStream { properties.load(it) }
-        def flutterSdkPath = properties.getProperty("flutter.sdk")
-        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        file('local.properties').withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty('flutter.sdk')
+        assert flutterSdkPath != null, 'flutter.sdk not set in local.properties'
         return flutterSdkPath
     }()
 
@@ -16,11 +16,10 @@ pluginManagement {
     }
 }
 
-
 plugins {
-    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.8.2' apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id 'dev.flutter.flutter-plugin-loader' version '1.0.0'
+    id 'com.android.application' version '8.12.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.1.0' apply false
 }
 
-include ":app"
+include ':app'

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEVELOPMENT_TEAM = 693LG6K34L;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -552,7 +552,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEVELOPMENT_TEAM = 693LG6K34L;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -588,7 +588,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 65;
+				CURRENT_PROJECT_VERSION = 66;
 				DEVELOPMENT_TEAM = 693LG6K34L;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>8.1.0</string>
+	<string>8.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>65</string>
+	<string>66</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>sms</string>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,6 +1,6 @@
 default_platform(:ios)
 
-VERSION_NUMBER = "8.1.0"
+VERSION_NUMBER = "8.1.1"
 
 platform :ios do
   before_all do
@@ -23,7 +23,7 @@ platform :ios do
     configuration: "Release",  # Bu satırı ekleyin
     xcargs: "-allowProvisioningUpdates"
   )
-  
+
   upload_to_testflight
   end
 

--- a/ios/fastlane/report.xml
+++ b/ios/fastlane/report.xml
@@ -5,37 +5,37 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000173">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.000233">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: automatic_code_signing" time="0.045479">
+      <testcase classname="fastlane.lanes" name="1: automatic_code_signing" time="0.0492">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: increment_version_number" time="0.155396">
+      <testcase classname="fastlane.lanes" name="2: increment_version_number" time="0.194736">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: latest_testflight_build_number" time="6.569092">
+      <testcase classname="fastlane.lanes" name="3: latest_testflight_build_number" time="2.542026">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="4: increment_build_number" time="0.15574">
+      <testcase classname="fastlane.lanes" name="4: increment_build_number" time="0.168933">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="5: gym" time="281.819936">
+      <testcase classname="fastlane.lanes" name="5: gym" time="485.126535">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="6: upload_to_testflight" time="563.118939">
+      <testcase classname="fastlane.lanes" name="6: upload_to_testflight" time="555.790275">
         
       </testcase>
     

--- a/lib/features/chain_store/provider/chain_store_provider.g.dart
+++ b/lib/features/chain_store/provider/chain_store_provider.g.dart
@@ -6,6 +6,9 @@ part of 'chain_store_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(ChainStoreProvider)
 const chainStoreProviderProvider = ChainStoreProviderProvider._();
 
@@ -56,6 +59,3 @@ abstract class _$ChainStoreProvider extends $Notifier<ChainStoreState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/details/provider/event_detail_provider.g.dart
+++ b/lib/features/details/provider/event_detail_provider.g.dart
@@ -6,6 +6,9 @@ part of 'event_detail_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(EventDetailProvider)
 const eventDetailProviderProvider = EventDetailProviderProvider._();
 
@@ -56,6 +59,3 @@ abstract class _$EventDetailProvider extends $Notifier<EventDetailState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/details/view_model/place_detail_view_model.g.dart
+++ b/lib/features/details/view_model/place_detail_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'place_detail_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(PlaceDetailViewModel)
 const placeDetailViewModelProvider = PlaceDetailViewModelProvider._();
 
@@ -56,6 +59,3 @@ abstract class _$PlaceDetailViewModel extends $Notifier<PlaceDetailState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/main/event/provider/event_view_model.g.dart
+++ b/lib/features/main/event/provider/event_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'event_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(EventViewModel)
 const eventViewModelProvider = EventViewModelProvider._();
 
@@ -52,6 +55,3 @@ abstract class _$EventViewModel extends $Notifier<EventState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/main/history/provider/history_view_model.g.dart
+++ b/lib/features/main/history/provider/history_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'history_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(HistoryViewModel)
 const historyViewModelProvider = HistoryViewModelProvider._();
 
@@ -55,6 +58,3 @@ abstract class _$HistoryViewModel extends $Notifier<HistoryState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/main/home/provider/home_view_model.g.dart
+++ b/lib/features/main/home/provider/home_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'home_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(HomeViewModel)
 const homeViewModelProvider = HomeViewModelProvider._();
 
@@ -52,6 +55,3 @@ abstract class _$HomeViewModel extends $Notifier<HomeState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/main/news_jobs/provider/news_jobs_provider.g.dart
+++ b/lib/features/main/news_jobs/provider/news_jobs_provider.g.dart
@@ -6,6 +6,9 @@ part of 'news_jobs_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(NewsJobsProvider)
 const newsJobsProviderProvider = NewsJobsProviderProvider._();
 
@@ -55,6 +58,3 @@ abstract class _$NewsJobsProvider extends $Notifier<NewsJobsState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sub_feature/developers/provider/developers_view_model.g.dart
+++ b/lib/features/sub_feature/developers/provider/developers_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'developers_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(DevelopersViewModel)
 const developersViewModelProvider = DevelopersViewModelProvider._();
 
@@ -56,6 +59,3 @@ abstract class _$DevelopersViewModel extends $Notifier<DevelopersState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sub_feature/favorite/provider/favorite_view_model.g.dart
+++ b/lib/features/sub_feature/favorite/provider/favorite_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'favorite_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(FavoriteViewModel)
 const favoriteViewModelProvider = FavoriteViewModelProvider._();
 
@@ -38,7 +41,7 @@ final class FavoriteViewModelProvider
   }
 }
 
-String _$favoriteViewModelHash() => r'cc6d1254e810e73c6d179a3506ddc613cfa18353';
+String _$favoriteViewModelHash() => r'057dcbe3d95a8f73c880d57eea07146941af1902';
 
 abstract class _$FavoriteViewModel extends $Notifier<FavoriteState> {
   FavoriteState build();
@@ -55,6 +58,3 @@ abstract class _$FavoriteViewModel extends $Notifier<FavoriteState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sub_feature/filter_and_search/provider/filter_search_provider.g.dart
+++ b/lib/features/sub_feature/filter_and_search/provider/filter_search_provider.g.dart
@@ -6,6 +6,9 @@ part of 'filter_search_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(FilterWithSearch)
 const filterWithSearchProvider = FilterWithSearchProvider._();
 
@@ -55,6 +58,3 @@ abstract class _$FilterWithSearch extends $Notifier<FilterSearchState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sub_feature/forms/place_request/provider/place_request_provider.g.dart
+++ b/lib/features/sub_feature/forms/place_request/provider/place_request_provider.g.dart
@@ -6,6 +6,9 @@ part of 'place_request_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(PlaceRequestProvider)
 const placeRequestProviderProvider = PlaceRequestProviderProvider._();
 
@@ -56,6 +59,3 @@ abstract class _$PlaceRequestProvider extends $Notifier<PlaceRequestState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sub_feature/forms/project_request/provider/project_request_provider.g.dart
+++ b/lib/features/sub_feature/forms/project_request/provider/project_request_provider.g.dart
@@ -6,6 +6,9 @@ part of 'project_request_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(ProjectRequestProvider)
 const projectRequestProviderProvider = ProjectRequestProviderProvider._();
 
@@ -56,6 +59,3 @@ abstract class _$ProjectRequestProvider extends $Notifier<ProjectRequestState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sub_feature/forms/scholarship_request/provider/scholarship_request_provider.g.dart
+++ b/lib/features/sub_feature/forms/scholarship_request/provider/scholarship_request_provider.g.dart
@@ -6,6 +6,9 @@ part of 'scholarship_request_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(ScholarshipRequestProvider)
 const scholarshipRequestProviderProvider =
     ScholarshipRequestProviderProvider._();
@@ -59,6 +62,3 @@ abstract class _$ScholarshipRequestProvider
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sub_feature/special_agency/provider/special_agency_view_model.g.dart
+++ b/lib/features/sub_feature/special_agency/provider/special_agency_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'special_agency_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(SpecialAgencyViewModel)
 const specialAgencyViewModelProvider = SpecialAgencyViewModelProvider._();
 
@@ -56,6 +59,3 @@ abstract class _$SpecialAgencyViewModel extends $Notifier<SpecialAgencyState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/sub_feature/useful_links/provider/useful_links_view_model.g.dart
+++ b/lib/features/sub_feature/useful_links/provider/useful_links_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'useful_links_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(UsefulLinksViewModel)
 const usefulLinksViewModelProvider = UsefulLinksViewModelProvider._();
 
@@ -56,6 +59,3 @@ abstract class _$UsefulLinksViewModel extends $Notifier<UsefulLinksState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/tourism/provider/tourism_view_model.g.dart
+++ b/lib/features/tourism/provider/tourism_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'tourism_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(TourismViewModel)
 const tourismViewModelProvider = TourismViewModelProvider._();
 
@@ -55,6 +58,3 @@ abstract class _$TourismViewModel extends $Notifier<TourismState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/sub_feature/advertisement_board/provider/advertisement_board_view_model.g.dart
+++ b/lib/sub_feature/advertisement_board/provider/advertisement_board_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'advertisement_board_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(AdvertisementBoardViewModel)
 const advertisementBoardViewModelProvider =
     AdvertisementBoardViewModelProvider._();
@@ -59,6 +62,3 @@ abstract class _$AdvertisementBoardViewModel
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/sub_feature/main_tab/view_model/main_tab_view_model.g.dart
+++ b/lib/sub_feature/main_tab/view_model/main_tab_view_model.g.dart
@@ -6,6 +6,9 @@ part of 'main_tab_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
 @ProviderFor(MainTabViewModel)
 const mainTabViewModelProvider = MainTabViewModelProvider._();
 
@@ -55,6 +58,3 @@ abstract class _$MainTabViewModel extends $Notifier<MainTabState> {
     element.handleValue(ref, created);
   }
 }
-
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
   life_shared:
     git:
       url: https://github.com/VB-CORE/life_shared.git
-      ref: v5.4.10
+      ref: v5.4.2
 
   file_picker: ^8.0.5
   sliver_tools: ^0.2.12


### PR DESCRIPTION
- Updated version number in pubspec.yaml from v5.4.10 to v5.4.2 for dependency management.
- Incremented VERSION_NUMBER in Fastfile for both Android and iOS from 8.1.0 to 8.1.1.
- Adjusted CURRENT_PROJECT_VERSION in Info.plist and project.pbxproj from 65 to 66 for iOS.
- Updated test execution times in report.xml files for both Android and iOS to reflect recent performance metrics.
