### PR TITLE
ci: Add Dependabot configuration for pub package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      firebase-dependencies:
+        patterns:
+          - "firebase_*"
+      riverpod-dependencies:
+        patterns:
+          # Riverpod Core and Tools
+          - "*riverpod*" 
+          - "*json_annotation*"
+          - "*build_runner*" # build_runner is the core tool that runs the others
+          - "json_serializable"


### PR DESCRIPTION
Selam

Introduce a configuration file for Dependabot to manage updates for pub packages on a weekly schedule, including specific groups for Firebase and Riverpod dependencies.

I noticed that dependency updates are currently being handled manually. I've added a basic `.github/dependabot.yml` configuration to automate this workflow.

**What this does:**
Dependabot will automatically scan `pubspec.yaml` for outdated dependencies and open individual Pull Requests to upgrade them. This reduces maintenance overhead and ensures security patches are applied promptly.

**Reference:**
[GitHub Dependabot Documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates)