### PR TITLE
fix(ios): font_awesome_flutter v11 ve iOS 14 minimum deployment target

### DIFF
--- a/lib/features/details/view/event_detail_view.dart
+++ b/lib/features/details/view/event_detail_view.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:kartal/kartal.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/details/mixin/event_detail_mixin.dart';
@@ -46,7 +47,7 @@ class _EventDetailViewState extends ConsumerState<EventDetailView>
           ),
           IconButton(
             onPressed: sendAMessageWithPhone,
-            icon: const Icon(AppIcons.sendMessage),
+            icon: const FaIcon(AppIcons.sendMessage),
           ),
           _ShareAddressButton(model: eventModel),
         ],

--- a/lib/features/main/settings/view/widget/contact_us_widget.dart
+++ b/lib/features/main/settings/view/widget/contact_us_widget.dart
@@ -61,12 +61,12 @@ final class _ContactUsCard extends StatelessWidget {
           const EmptyBox.smallHeight(),
           _ContactTile(
             title: StringConstants.twitter,
-            icon: FontAwesomeIcons.xTwitter,
+            icon: const FaIcon(AppIcons.twitter),
             onTap: () => model.twitterUrl.ext.launchWebsite,
           ),
           _ContactTile(
             title: StringConstants.mail,
-            icon: Icons.mail_outline,
+            icon: const Icon(AppIcons.mail),
             onTap: () => model.mail.ext.launchEmail,
           ),
         ],
@@ -98,14 +98,14 @@ final class _ContactTile extends StatelessWidget {
     required this.onTap,
   });
   final String title;
-  final IconData icon;
+  final Widget icon;
   final VoidCallback onTap;
   @override
   Widget build(BuildContext context) {
     return ListTile(
       dense: true,
       title: GeneralBodyTitle(title),
-      trailing: Icon(icon),
+      trailing: icon,
       onTap: onTap,
     );
   }

--- a/lib/product/utility/constants/app_icons.dart
+++ b/lib/product/utility/constants/app_icons.dart
@@ -37,7 +37,9 @@ final class AppIcons {
   static const IconData favorite = Icons.favorite;
   static const IconData favoriteBorder = Icons.favorite_border_outlined;
 
-  static const IconData sendMessage = FontAwesomeIcons.whatsapp;
+  static const FaIconData sendMessage = FontAwesomeIcons.whatsapp;
+  static const FaIconData twitter = FontAwesomeIcons.xTwitter;
+  static const IconData mail = Icons.mail_outline;
   static const IconData notifications = Icons.notifications_outlined;
 
   static const IconData menu = Icons.menu_outlined;

--- a/lib/product/widget/circle_avatar/social_media_circle_avatar.dart
+++ b/lib/product/widget/circle_avatar/social_media_circle_avatar.dart
@@ -10,7 +10,7 @@ class SocialMediaCircleAvatar extends StatelessWidget {
     super.key,
   });
 
-  final IconData iconData;
+  final FaIconData iconData;
   final String webUrl;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,7 +82,7 @@ dependencies:
   dotted_border: ^3.1.0
   shimmer: ^3.0.0
   sliver_snap: ^2.0.0
-  font_awesome_flutter: ^10.5.0
+  font_awesome_flutter: ^11.0.0
 
   carousel_slider: ^5.0.0
   flutter_speed_dial: ^7.0.0


### PR DESCRIPTION
Closes #340

## Sorun

### 1. font_awesome_flutter uyumsuzluğu
Flutter 3.27+ ile birlikte `IconData` sınıfı `final` yapıldı.
`font_awesome_flutter 10.x` kendi `IconData` subclass'ı üzerinden çalıştığı için derleme hatası veriyor:

```
Error: The class 'IconData' can't be extended outside of its library because it's a final class.
```

### 2. iOS minimum deployment target
`google_maps_flutter_ios` minimum iOS 14.0 gerektiriyor fakat projede 13.0 yazıyor, pod install başarısız oluyor.

## Çözüm

- `pubspec.yaml`: `font_awesome_flutter ^10.5.0` → `^11.0.0`
- `ios/Podfile`: `platform :ios, "13.0"` → `"14.0"`
- `ios/Runner.xcodeproj/project.pbxproj`: `IPHONEOS_DEPLOYMENT_TARGET` 13.0 → 14.0 (6 yerde)
- `lib/product/utility/constants/app_icons.dart`: `sendMessage` ve `twitter` sabitleri `FaIconData` tipine güncellendi, `mail` sabiti eklendi
- `lib/features/details/view/event_detail_view.dart`: `Icon` → `FaIcon` kullanımı güncellendi
- `lib/features/main/settings/view/widget/contact_us_widget.dart`: `FontAwesomeIcons.*` direkt kullanımı kaldırıldı, `AppIcons` sabitlerinden alınacak şekilde düzeltildi
- `lib/product/widget/circle_avatar/social_media_circle_avatar.dart`: `IconData` → `FaIconData` tipi güncellendi