### PR TITLE
fix(android): bump Kotlin version to 2.3.0 for maps utils compatibility

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id 'dev.flutter.flutter-plugin-loader' version '1.0.0'
     id 'com.android.application' version '8.12.0' apply false
-    id 'org.jetbrains.kotlin.android' version '2.1.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.3.0' apply false
 }
 
 include ':app'


### PR DESCRIPTION
Closes #342

## Sorun
google_maps_flutter_android paketi android-maps-utils 4.1.0 bagimliligi cekiyor.
Bu kutuphane Kotlin 2.3.0 ile derlendi, projede ise 2.1.0 tanimli.

## Cozum
- android/settings.gradle: org.jetbrains.kotlin.android 2.1.0 -> 2.3.0