### PR TITLE
refactor(theme): migrate color palette from ColorsCustom to AppColors

### DIFF
--- a/lib/features/main/history/widget/history_favorite_view.dart
+++ b/lib/features/main/history/widget/history_favorite_view.dart
@@ -8,7 +8,7 @@ import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/package/image/custom_network_image.dart';
 import 'package:lifeclient/product/utility/constants/app_icon_sizes.dart';
 import 'package:lifeclient/product/utility/constants/app_icons.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 import 'package:lifeclient/product/utility/decorations/custom_radius.dart';
 import 'package:lifeclient/product/widget/button/memory_favorite_button.dart';
 
@@ -64,14 +64,14 @@ final class _HistoryFavoriteSheetState extends State<HistoryFavoriteSheet> {
           const Icon(
             AppIcons.favoriteBorder,
             size: AppIconSizes.xLarge * 2,
-            color: ColorsCustom.warmGrey,
+            color: AppColors.ink400,
           ),
           const SizedBox(height: AppIconSizes.medium),
           Text(
             LocaleKeys.historyPage_favorites_emptyTitle.tr(),
             style: context.general.textTheme.titleMedium?.copyWith(
               fontSize: AppIconSizes.medium,
-              color: ColorsCustom.warmGrey,
+              color: AppColors.ink400,
               fontWeight: FontWeight.w600,
             ),
           ),
@@ -81,7 +81,7 @@ final class _HistoryFavoriteSheetState extends State<HistoryFavoriteSheet> {
             textAlign: TextAlign.center,
             style: context.general.textTheme.bodyMedium?.copyWith(
               fontSize: AppIconSizes.small,
-              color: ColorsCustom.warmGrey,
+              color: AppColors.ink400,
             ),
           ),
         ],
@@ -127,7 +127,7 @@ final class _HistoryFavoriteSheetState extends State<HistoryFavoriteSheet> {
             : const Icon(
                 AppIcons.gallery,
                 size: AppIconSizes.large,
-                color: ColorsCustom.warmGrey,
+                color: AppColors.ink400,
               ),
       ),
     );
@@ -153,7 +153,7 @@ final class _HistoryFavoriteSheetState extends State<HistoryFavoriteSheet> {
       maxLines: 2,
       overflow: TextOverflow.ellipsis,
       style: context.general.textTheme.bodySmall?.copyWith(
-        color: ColorsCustom.warmGrey,
+        color: AppColors.ink400,
       ),
     );
   }

--- a/lib/features/main/history/widget/history_info_dialog.dart
+++ b/lib/features/main/history/widget/history_info_dialog.dart
@@ -7,7 +7,7 @@ import 'package:lifeclient/product/model/enum/firebase_remote_enums.dart';
 import 'package:lifeclient/product/package/image/custom_network_image.dart';
 import 'package:lifeclient/product/utility/constants/app_icon_sizes.dart';
 import 'package:lifeclient/product/utility/constants/app_icons.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 import 'package:lifeclient/product/utility/decorations/custom_radius.dart';
 
 @immutable
@@ -75,17 +75,17 @@ final class _InfoBox extends StatelessWidget {
     return Container(
       padding: const PagePadding.generalAllLow(),
       decoration: BoxDecoration(
-        color: ColorsCustom.brandeisBlue.withValues(alpha: _opacity),
+        color: AppColors.teal.withValues(alpha: _opacity),
         borderRadius: CustomRadius.small,
         border: Border.all(
-          color: ColorsCustom.brandeisBlue.withValues(alpha: _borderOpacity),
+          color: AppColors.teal.withValues(alpha: _borderOpacity),
         ),
       ),
       child: Row(
         children: [
           const Icon(
             AppIcons.addPhoto,
-            color: ColorsCustom.brandeisBlue,
+            color: AppColors.teal,
             size: AppIconSizes.medium,
           ),
           const SizedBox(width: AppIconSizes.small),
@@ -93,7 +93,7 @@ final class _InfoBox extends StatelessWidget {
             child: Text(
               LocaleKeys.historyPage_addPhotoInfo.tr(),
               style: context.general.textTheme.bodySmall?.copyWith(
-                color: ColorsCustom.brandeisBlue,
+                color: AppColors.teal,
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -115,7 +115,7 @@ final class _DialogAction extends StatelessWidget {
       child: Text(
         LocaleKeys.button_understood.tr(),
         style: context.general.textTheme.labelLarge?.copyWith(
-          color: ColorsCustom.brandeisBlue,
+          color: AppColors.teal,
           fontWeight: FontWeight.w600,
         ),
       ),

--- a/lib/features/main/history/widget/history_photo_detail_sheet.dart
+++ b/lib/features/main/history/widget/history_photo_detail_sheet.dart
@@ -7,7 +7,7 @@ import 'package:lifeclient/product/package/image/custom_network_image.dart';
 import 'package:lifeclient/product/package/share/custom_share.dart';
 import 'package:lifeclient/product/utility/constants/app_icon_sizes.dart';
 import 'package:lifeclient/product/utility/constants/app_icons.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 import 'package:lifeclient/product/widget/button/memory_favorite_button.dart';
 
 @immutable
@@ -45,7 +45,7 @@ class _HistoryPhotoDetailSheetState
     return Container(
       height: context.sized.dynamicHeight(_heightRatio),
       decoration: const BoxDecoration(
-        color: ColorsCustom.black,
+        color: AppColors.ink900,
         borderRadius: BorderRadius.vertical(
           top: Radius.circular(AppIconSizes.medium),
         ),
@@ -122,7 +122,7 @@ final class _CounterText extends StatelessWidget {
     return Text(
       '${currentIndex + _indexOffset} / $totalCount',
       style: context.general.textTheme.titleMedium?.copyWith(
-        color: ColorsCustom.white,
+        color: AppColors.white,
         fontWeight: FontWeight.w500,
       ),
     );
@@ -139,7 +139,7 @@ final class _CloseButton extends StatelessWidget {
       onPressed: () => Navigator.of(context).pop(),
       icon: const Icon(
         AppIcons.close,
-        color: ColorsCustom.white,
+        color: AppColors.white,
         size: AppIconSizes.large,
       ),
     );
@@ -205,8 +205,8 @@ final class _BottomInfo extends StatelessWidget {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            ColorsCustom.transparent,
-            ColorsCustom.black.withValues(alpha: _gradientOpacity),
+            Colors.transparent,
+            AppColors.ink900.withValues(alpha: _gradientOpacity),
           ],
         ),
       ),
@@ -246,7 +246,7 @@ final class _MemoryTitle extends StatelessWidget {
     return Text(
       title!,
       style: context.general.textTheme.headlineSmall?.copyWith(
-        color: ColorsCustom.white,
+        color: AppColors.white,
         fontWeight: FontWeight.bold,
       ),
     );
@@ -269,7 +269,7 @@ final class _MemoryDescription extends StatelessWidget {
     return Text(
       description!,
       style: context.general.textTheme.bodyMedium?.copyWith(
-        color: ColorsCustom.white,
+        color: AppColors.white,
         fontWeight: FontWeight.w800,
       ),
     );
@@ -309,7 +309,7 @@ final class _ShareButton extends StatelessWidget {
       onPressed: () => CustomShare.shareMemory(memory),
       icon: const Icon(
         AppIcons.share,
-        color: ColorsCustom.white,
+        color: AppColors.white,
         size: AppIconSizes.medium,
       ),
     );

--- a/lib/product/common/color_common.dart
+++ b/lib/product/common/color_common.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kartal/kartal.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 
 /// more detail for look at
 /// https://m3.material.io/styles/color/the-color-system/tokens
@@ -9,8 +9,8 @@ final class ColorCommon {
 
   final BuildContext context;
 
-  static const Color sameWhiteColor = ColorsCustom.white;
-  static const Color linkColor = ColorsCustom.brandeisBlue;
+  static const Color sameWhiteColor = AppColors.white;
+  static const Color linkColor = AppColors.teal;
 
   /// means [ThemeData].light == white
   Color get whiteAndBlackForTheme {

--- a/lib/product/init/application_theme.dart
+++ b/lib/product/init/application_theme.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:lifeclient/product/utility/constants/index.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 import 'package:lifeclient/product/utility/decorations/custom_radius.dart';
 
 final class ApplicationTheme {
@@ -105,9 +105,9 @@ final class ApplicationTheme {
         color: colorScheme.primary,
       ),
       snackBarTheme: SnackBarThemeData(
-        backgroundColor: isDark ? _darkSurfaceElevated : ColorsCustom.sambacus,
+        backgroundColor: isDark ? _darkSurfaceElevated : AppColors.navy,
         contentTextStyle: textTheme.bodyMedium?.copyWith(
-          color: isDark ? _darkText : ColorsCustom.white,
+          color: isDark ? _darkText : AppColors.white,
         ),
         actionTextColor: colorScheme.primary,
       ),
@@ -131,22 +131,20 @@ final class ApplicationTheme {
     required bool isDark,
   }) {
     return currentScheme.copyWith(
-      primary: isDark ? _darkPrimary : ColorsCustom.sambacus,
-      secondary: isDark ? _darkSurfaceElevated : ColorsCustom.white,
-      surface: isDark ? _darkSurface : ColorsCustom.white,
-      onSurface: isDark ? _darkText : ColorsCustom.sambacus,
-      onPrimary: isDark ? ColorsCustom.sambacus : ColorsCustom.white,
-      onPrimaryContainer: isDark ? _darkBorder : ColorsCustom.lightGray,
-      onPrimaryFixed: isDark ? _darkSurfaceElevated : ColorsCustom.gray,
-      error: ColorsCustom.imperilRead,
-      primaryContainer: isDark ? _darkSuccess : ColorsCustom.braziliante,
-      onTertiaryContainer: isDark ? _darkSuccessText : ColorsCustom.green,
-      onSecondaryContainer: isDark ? _darkPrimary : ColorsCustom.royalPeacock,
-      onSecondaryFixed: isDark ? _darkMuted : ColorsCustom.warmGrey,
-      onPrimaryFixedVariant: isDark ? _darkText : ColorsCustom.darkGray,
-      onTertiaryFixedVariant: isDark
-          ? _darkAccent
-          : ColorsCustom.underlinePurple,
+      primary: isDark ? _darkPrimary : AppColors.navy,
+      secondary: isDark ? _darkSurfaceElevated : AppColors.white,
+      surface: isDark ? _darkSurface : AppColors.surface,
+      onSurface: isDark ? _darkText : AppColors.ink900,
+      onPrimary: isDark ? AppColors.navy : AppColors.white,
+      onPrimaryContainer: isDark ? _darkBorder : AppColors.ink200,
+      onPrimaryFixed: isDark ? _darkSurfaceElevated : AppColors.ink25,
+      error: AppColors.coral,
+      primaryContainer: isDark ? _darkSuccess : AppColors.olive,
+      onTertiaryContainer: isDark ? _darkSuccessText : AppColors.olive,
+      onSecondaryContainer: isDark ? _darkPrimary : AppColors.teal,
+      onSecondaryFixed: isDark ? _darkMuted : AppColors.ink400,
+      onPrimaryFixedVariant: isDark ? _darkText : AppColors.ink500,
+      onTertiaryFixedVariant: isDark ? _darkAccent : AppColors.teal,
     );
   }
 

--- a/lib/product/package/file_picker/upload_file_section_v2.dart
+++ b/lib/product/package/file_picker/upload_file_section_v2.dart
@@ -8,7 +8,7 @@ import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/package/file_picker/file_extension_enum.dart';
 import 'package:lifeclient/product/package/file_picker/upload_file_v2_mixin.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 import 'package:lifeclient/product/utility/decorations/empty_box.dart';
 import 'package:lifeclient/product/widget/general/index.dart';
 import 'package:lifeclient/product/widget/general/title/general_body_small_title.dart';
@@ -50,7 +50,7 @@ class UploadFileSectionV2State extends State<UploadFileSection>
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(WidgetSizes.spacingS),
             border: Border.all(
-              color: ColorsCustom.softGray,
+              color: AppColors.ink100,
               width: 2,
             ),
           ),

--- a/lib/product/package/photo_picker/dotted_add_photo_button.dart
+++ b/lib/product/package/photo_picker/dotted_add_photo_button.dart
@@ -6,7 +6,7 @@ import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/model/constant/project_general_constant.dart';
 import 'package:lifeclient/product/package/photo_picker/add_photo_mixin.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 import 'package:lifeclient/product/utility/decorations/custom_radius.dart';
 import 'package:lifeclient/product/widget/border/dotted_border_custom.dart';
 
@@ -87,12 +87,12 @@ class _FileImageWithUpdate extends StatelessWidget {
           child: IconButton(
             style: TextButton.styleFrom(
               shape: const CircleBorder(),
-              backgroundColor: ColorsCustom.sambacus,
+              backgroundColor: AppColors.navy,
             ),
             onPressed: onUpdateTap,
             icon: const Icon(
               Icons.edit,
-              color: ColorsCustom.white,
+              color: AppColors.white,
             ),
           ),
         ),

--- a/lib/product/utility/decorations/app_colors.dart
+++ b/lib/product/utility/decorations/app_colors.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+abstract final class AppColors {
+  // ── PRIMARY · Lacivert ──
+  static const navy = Color(0xFF0F2A47);
+  static const navy50 = Color(0xFFEAEEF3);
+  static const navy100 = Color(0xFFCBD4E0);
+  static const navy200 = Color(0xFF94A4B9);
+  static const navy300 = Color(0xFF5C7491);
+  static const navy400 = Color(0xFF2E4D70);
+  static const navy500 = Color(0xFF0F2A47);
+  static const navy600 = Color(0xFF0B2138);
+  static const navy700 = Color(0xFF08182A);
+  static const navy800 = Color(0xFF050F1B);
+  static const navy900 = Color(0xFF02060D);
+
+  // ── ACCENT · Mercan ──
+  static const coral = Color(0xFFE84B3C);
+  static const coral50 = Color(0xFFFDECEA);
+  static const coral100 = Color(0xFFFACFCB);
+  static const coral200 = Color(0xFFF4A097);
+  static const coral300 = Color(0xFFEE7263);
+  static const coral400 = Color(0xFFEA5B4D);
+  static const coral500 = Color(0xFFE84B3C);
+  static const coral600 = Color(0xFFCD3A2C);
+  static const coral700 = Color(0xFFA12C20);
+  static const coral800 = Color(0xFF751F17);
+  static const coral900 = Color(0xFF4A130E);
+
+  // ── SECONDARY · Turkuaz ──
+  static const teal = Color(0xFF3CB6C9);
+  static const teal50 = Color(0xFFE5F5F8);
+  static const teal100 = Color(0xFFBFE7EE);
+  static const teal200 = Color(0xFF8FD4DF);
+  static const teal300 = Color(0xFF5EC0CF);
+  static const teal400 = Color(0xFF3CB6C9);
+  static const teal500 = Color(0xFF2A9DAF);
+  static const teal600 = Color(0xFF207E8C);
+  static const teal700 = Color(0xFF185E68);
+  static const teal800 = Color(0xFF103E45);
+
+  // ── SUCCESS · Yeşil ──
+  static const olive = Color(0xFF7FBE3F);
+  static const olive50 = Color(0xFFF2F9E8);
+  static const olive100 = Color(0xFFDCEEC0);
+  static const olive200 = Color(0xFFBDDF92);
+  static const olive300 = Color(0xFF9DCF63);
+  static const olive400 = Color(0xFF7FBE3F);
+  static const olive500 = Color(0xFF67A030);
+  static const olive600 = Color(0xFF4F7C25);
+  static const olive700 = Color(0xFF385819);
+
+  // ── NÖTR ──
+  static const white = Color(0xFFFFFFFF);
+  static const bg = Color(0xFFF7F9FB);
+  static const bgDeep = Color(0xFFEEF2F6);
+  static const surface = Color(0xFFFFFFFF);
+  static const ink25 = Color(0xFFF7F9FB);
+  static const ink50 = Color(0xFFEEF2F6);
+  static const ink100 = Color(0xFFE1E7EE);
+  static const ink200 = Color(0xFFCBD3DC);
+  static const ink300 = Color(0xFFA8B2BE);
+  static const ink400 = Color(0xFF7A8593);
+  static const ink500 = Color(0xFF566270);
+  static const ink600 = Color(0xFF3A4452);
+  static const ink700 = Color(0xFF26303D);
+  static const ink800 = Color(0xFF16202C);
+  static const ink900 = Color(0xFF0A1320);
+
+  // ── Anma altını ──
+  static const gold = Color(0xFFA87D15);
+  static const gold200 = Color(0xFFE9CE7E);
+  static const gold300 = Color(0xFFDDB74B);
+}

--- a/lib/product/utility/decorations/colors_custom.dart
+++ b/lib/product/utility/decorations/colors_custom.dart
@@ -1,22 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 
+@Deprecated('Use AppColors instead')
 @immutable
 final class ColorsCustom {
   const ColorsCustom._();
-  static const Color sambacus = Color(0xFF101A2A);
-  static const Color endless = Color(0xFFE23E3E);
-  static const Color braziliante = Color(0xFF34C759);
+  static const Color sambacus = AppColors.navy;
+  static const Color endless = AppColors.coral;
+  static const Color braziliante = AppColors.olive;
   static const Color brandeisBlue = Color(0xFF0D6EFD);
-  static const Color lightGray = Color(0xffCED4DA);
-  static const Color softGray = Color.fromRGBO(219, 219, 219, 1);
-  static const Color gray = Color.fromRGBO(245, 245, 245, 1);
-  static const Color warmGrey = Color.fromRGBO(153, 153, 153, 1);
-  static const Color darkGray = Color.fromRGBO(91, 91, 91, 1);
+  static const Color lightGray = AppColors.ink200;
+  static const Color softGray = AppColors.ink100;
+  static const Color gray = AppColors.ink25;
+  static const Color warmGrey = AppColors.ink400;
+  static const Color darkGray = AppColors.ink500;
   static const Color underlinePurple = Color.fromRGBO(82, 0, 255, 1);
-  static const Color white = Color(0xFFFFffff);
-  static const Color imperilRead = Color(0xffEF2636);
-  static const Color royalPeacock = Color(0xff27AAE5);
-  static const Color transparent = Color(0x00000000);
-  static const Color black = Color(0xFF000000);
-  static const Color green = Color(0xFF00FF00);
+  static const Color white = AppColors.white;
+  static const Color imperilRead = AppColors.coral;
+  static const Color royalPeacock = Color(0xFF27AAE5);
+  static const Color transparent = Colors.transparent;
+  static const Color black = AppColors.ink900;
+  static const Color green = AppColors.olive;
 }

--- a/lib/product/utility/decorations/index.dart
+++ b/lib/product/utility/decorations/index.dart
@@ -1,3 +1,4 @@
+export 'app_colors.dart';
 export 'box_decorations.dart';
 export 'colors_custom.dart';
 export 'custom_border_side.dart';

--- a/lib/product/utility/decorations/style/custom_button_style.dart
+++ b/lib/product/utility/decorations/style/custom_button_style.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:life_shared/life_shared.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 
 @immutable
 class CustomButtonStyle extends ButtonStyle {
@@ -10,7 +10,7 @@ class CustomButtonStyle extends ButtonStyle {
     return OutlinedButton.styleFrom(
       padding: const PagePadding.verticalSymmetric(),
       side: const BorderSide(
-        color: ColorsCustom.sambacus,
+        color: AppColors.navy,
         width: 3,
       ),
     );

--- a/lib/product/widget/button/active_button.dart
+++ b/lib/product/widget/button/active_button.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kartal/kartal.dart';
 import 'package:life_shared/life_shared.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 
 class ActiveButton extends StatelessWidget {
   const ActiveButton({required this.label, required this.onPressed, super.key});
@@ -14,14 +14,14 @@ class ActiveButton extends StatelessWidget {
       onPressed: onPressed,
       style: ElevatedButton.styleFrom(
         padding: const PagePadding.generalAllNormal(),
-        backgroundColor: ColorsCustom.sambacus,
+        backgroundColor: AppColors.navy,
       ),
       child: Text(
         label,
         style: context.general.textTheme.titleMedium?.copyWith(
           fontWeight: FontWeight.w500,
           color: onPressed == null
-              ? ColorsCustom.sambacus.withOpacity(0.5)
+              ? AppColors.navy.withOpacity(0.5)
               : Colors.white,
         ),
       ),

--- a/lib/product/widget/button/memory_favorite_button.dart
+++ b/lib/product/widget/button/memory_favorite_button.dart
@@ -7,7 +7,7 @@ import 'package:lifeclient/product/feature/cache/hive_v2/model/memory_cache_mode
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/utility/constants/app_icon_sizes.dart';
 import 'package:lifeclient/product/utility/constants/app_icons.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 
 /// Memory favorite button widget for toggling favorite status
 final class MemoryFavoriteButton extends ConsumerStatefulWidget {
@@ -31,7 +31,7 @@ class _MemoryFavoriteButtonState extends ConsumerState<MemoryFavoriteButton>
       onPressed: _toggleFavorite,
       icon: Icon(
         _isFavorite ? AppIcons.favorite : AppIcons.favoriteBorder,
-        color: _isFavorite ? ColorsCustom.imperilRead : ColorsCustom.white,
+        color: _isFavorite ? AppColors.coral : AppColors.white,
         size: AppIconSizes.medium,
       ),
     );
@@ -93,7 +93,7 @@ mixin _MemoryFavoriteButtonMixin
     appProvider.scaffoldMessengerKey.currentState?.showSnackBar(
       SnackBar(
         content: Text(message),
-        backgroundColor: ColorsCustom.brandeisBlue,
+        backgroundColor: AppColors.teal,
       ),
     );
   }

--- a/lib/product/widget/checkbox/product_checkbox.dart
+++ b/lib/product/widget/checkbox/product_checkbox.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lifeclient/product/utility/constants/app_constants.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 
 class ProductCheckbox extends FormField<bool> {
   ProductCheckbox({
@@ -15,7 +15,7 @@ class ProductCheckbox extends FormField<bool> {
             return ListTile(
               minLeadingWidth: 0,
               leading: Checkbox(
-                activeColor: ColorsCustom.sambacus,
+                activeColor: AppColors.navy,
                 value: state.value,
                 onChanged: (value) {
                   state.didChange(value);

--- a/lib/product/widget/text/button_large_text.dart
+++ b/lib/product/widget/text/button_large_text.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kartal/kartal.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 import 'package:responsive_builder/responsive_builder.dart';
 
 class ButtonLargeText extends StatelessWidget {
@@ -21,7 +21,7 @@ class ButtonLargeText extends StatelessWidget {
         desktop: context.general.textTheme.headlineLarge,
       )?.copyWith(
         fontWeight: FontWeight.bold,
-        color: ColorsCustom.white,
+        color: AppColors.white,
       ),
     );
   }

--- a/lib/product/widget/text/button_normal_text.dart
+++ b/lib/product/widget/text/button_normal_text.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:kartal/kartal.dart';
 import 'package:responsive_builder/responsive_builder.dart';
 
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
+import 'package:lifeclient/product/utility/decorations/app_colors.dart';
 
 class ButtonNormalText extends StatelessWidget {
   const ButtonNormalText({
@@ -22,7 +22,7 @@ class ButtonNormalText extends StatelessWidget {
         desktop: context.general.textTheme.titleLarge,
       )?.copyWith(
         fontWeight: FontWeight.bold,
-        color: ColorsCustom.sambacus,
+        color: AppColors.navy,
       ),
     );
   }

--- a/lib/sub_feature/main_tab/main_tab_view.dart
+++ b/lib/sub_feature/main_tab/main_tab_view.dart
@@ -9,7 +9,6 @@ import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/navigation/app_router.dart';
 import 'package:lifeclient/product/utility/constants/app_constants.dart';
 import 'package:lifeclient/product/utility/constants/app_icons.dart';
-import 'package:lifeclient/product/utility/decorations/colors_custom.dart';
 import 'package:lifeclient/product/utility/mixin/index.dart';
 import 'package:lifeclient/product/widget/general/semantics/general_semantic.dart';
 import 'package:lifeclient/product/widget/general/semantics/general_semantic_keys.dart';


### PR DESCRIPTION
Closes #353

## Ne Yapıldı

- `AppColors` renk token sınıfı oluşturuldu (`lib/product/utility/decorations/app_colors.dart`) — UI Kit standardındaki 60+ semantik token (navy, coral, teal, olive, ink skalası, gold)
- `application_theme.dart` ColorScheme light mode mapping'leri AppColors'a geçirildi → 103 dosya otomatik olarak yeni renkleri kullanıyor
- `ColorsCustom` doğrudan kullanan 17 widget/feature dosyası AppColors'a migrate edildi
- `ColorsCustom` sınıfı içindeki hex değerleri AppColors referanslarına yönlendirildi
- `ColorsCustom` sınıfı `@Deprecated('Use AppColors instead')` olarak işaretlendi, geriye dönük uyumluluk için silinmedi

## Kapsam Dışı Bırakılanlar

- Tipografi / font değişikliği (ayrı iş)
- İkon seti değişikliği (`font_awesome` → `material_symbols_icons`) (ayrı iş)
- Dark mode (ekip kararı bekleniyor — bkz. PR #336 çakışması)

## Açık Kalan Kararlar

Aşağıdaki 3 renk için AppColors'da karşılık yok, şimdilik orijinal hex değerleri korundu:
- `brandeisBlue` (#0D6EFD) — bilgi kutusu arka planı, link rengi
- `royalPeacock` (#27AAE5) — ColorScheme onSecondaryContainer (dark mode)
- `underlinePurple` (#5200FF) — ColorScheme onTertiaryFixedVariant (dark mode)

Bu 3 renk için AppColors'a yeni token eklenmesi mi, yoksa mevcut bir token'a map edilmesi mi gerektiğine dair ekip kararı bekleniyor.

## Test

- `flutter analyze` temiz (hata yok)
- Light mode ColorScheme mapping'leri doğrulandı