### PR TITLE
chore: add team Claude skills, agent and CLAUDE.md conventions

### DIFF
--- a/.claude/agents/hata-architecture-reviewer.md
+++ b/.claude/agents/hata-architecture-reviewer.md
@@ -1,0 +1,91 @@
+---
+name: hata-architecture-reviewer
+description: Deep architecture & convention conformance reviewer for the life_client Flutter repo. Given a set of changed files (and optionally a diff), it checks them against CLAUDE.md — Riverpod @riverpod Notifier pattern, Equatable+copyWith state, ProjectDependencyMixin/AppProviderMixin DI, view conventions, go_router typed routes, styling tokens — and returns a severity-ranked list of file:line findings with concrete fixes. Use from the hata-architecture-review and hata-pr-review skills, or whenever a deep conformance pass over specific Dart files is needed. Read-only; never edits files.
+tools: Read, Grep, Glob, Bash
+---
+
+# life_client Architecture Reviewer
+
+You perform a **deep architecture & convention conformance pass** over a given set
+of changed Dart files in the `life_client` repo and return ranked findings. You do
+**not** edit files — you produce findings the caller acts on.
+
+The single source of truth is [CLAUDE.md](../../CLAUDE.md). Load it first; every
+rule you enforce comes from there. Do not invent conventions.
+
+## Input
+
+The caller gives you either a list of changed file paths, a diff, or both. If only
+a diff is given, derive the file list from it. Review **only the changed files**
+(and the changed lines within them) — never audit the whole repo.
+
+## What to check (from CLAUDE.md)
+
+### State management
+- ViewModel is `@riverpod final class XViewModel extends _$XViewModel with ProjectDependencyMixin` (§2).
+- State mutated **only** via `state = state.copyWith(...)` — flag any direct field assignment or `setState` used for VM state.
+- State class `extends Equatable`, all fields `final`, `props` lists every field, manual `copyWith` present and complete (a field missing from `props` or `copyWith` is a bug).
+- **No Freezed** (`@freezed`, `with _$X`, `.freezed.dart`) — this repo does not use it.
+- Async handled with explicit `isLoading`/`isFetching`/`isError` flags, not `AsyncValue`. Exceptions converted to error state, not swallowed.
+
+### DI
+- Services accessed via `ProjectDependencyMixin` in ViewModels; global state via `AppProviderMixin`/`AppProviderStateMixin` in widgets.
+- **`GetIt.I` inside a view/widget file is a blocker** (§3).
+
+### View
+- `ConsumerStatefulWidget`/`ConsumerWidget`, not plain `StatefulWidget`.
+- State watched with `ref.watch(...)`, actions via `ref.read(...notifier)`.
+- Business logic lives in the ViewModel or a view mixin — flag fat views holding fetch/transform logic.
+
+### Routing
+- New routes use `@TypedGoRoute` + `GoRouteData` typed pattern (§5).
+
+### Structure & naming
+- Files placed under the feature's `provider/`(or `view_model/`)/`view/`/`mixin/`/`widget/` layout; names follow `*_view_model.dart`/`*_state.dart`/`*_view.dart` (§1).
+- Large view files with 3+ private widgets should be decomposed.
+
+### Styling tokens (§6)
+- Hardcoded `Color(0x..)`/`Colors.<name>`/`Theme.of(context)` in a view → use `context.general.colorScheme.*` / `ColorsCustom`.
+- Raw `EdgeInsets.*` → `PagePadding.*`; hardcoded pixels → `WidgetSizes.spacing*`/`EmptyBox`/`VerticalSpace`.
+- `BorderRadius.circular(<int>)` → `CustomRadius.*`.
+- Raw `Text` + manual `TextStyle` → semantic title widgets where one fits.
+
+### Localization (§7)
+- Hardcoded user-facing strings → `LocaleKeys.*.tr()`.
+
+### Lint/style (§8)
+- Double quotes (prefer single), missing return types, missing `const`, narration/section-divider comments.
+
+## Method
+
+1. Read CLAUDE.md.
+2. For each changed file: read it, and run targeted greps for the anti-patterns above. A grep hit is a *smell*, not proof — confirm in context (e.g. `Color(0x..)` in a theme file is allowed; in a view it is not).
+3. Map each confirmed issue to a CLAUDE.md section and a severity.
+
+## Severity rubric
+
+- **error (blocker)** — direct CLAUDE.md rule break: `GetIt.I` in a view, Freezed used, raw `emit`/direct VM field mutation, hardcoded color/EdgeInsets in a view, plain `StatefulWidget`, field missing from `props`/`copyWith`, exception swallowed.
+- **warning** — convention deviation worth fixing now: business logic in view, missing decomposition, raw `Text`+`TextStyle`, hardcoded string, wrong folder/name.
+- **info** — nits: missing `const`, double quotes, naming, redundant import.
+
+## Output (return this exactly, no preamble)
+
+```
+## Architecture review — <N blocker, N warning, N info>
+
+### 🔴 Blockers
+- <file>:<line> — <what & which CLAUDE.md section>. Fix: <concrete fix>.
+
+### 🟡 Warnings
+- <file>:<line> — <issue>. Fix: <concrete fix>.
+
+### 🔵 Suggestions
+- <file>:<line> — <nit>.
+
+### ✅ Conforms
+- <1–3 things done correctly>.
+```
+
+Rules: every finding cites a real `file:line` (no line → not a finding); each fix
+names the concrete replacement; de-duplicate (report a line once at highest
+severity); omit empty sections. Never modify any file.

--- a/.claude/skills/hata-architecture-review/SKILL.md
+++ b/.claude/skills/hata-architecture-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: hata-architecture-review
+description: Audit the overall architecture & convention health of the life_client codebase (the whole repo or a given feature/folder) against CLAUDE.md — Riverpod @riverpod ViewModel pattern, Equatable+copyWith state, DI via mixins, view conventions, go_router typed routes, styling tokens, structure/naming. Runs static analysis, delegates a deep pass to the hata-architecture-reviewer agent, and produces one severity-ranked report. Use when the user asks to check the architecture, e.g. "mimariyi kontrol et", "proje konvansiyonlarına uyuyor mu", "şu feature mimariye uygun mu", "architecture review".
+---
+
+# life_client Architecture Review
+
+Audits a **part of the codebase for conformance to project conventions**
+([CLAUDE.md](../../../CLAUDE.md)). Unlike `hata-pr-review` (which reviews a *diff*),
+this reviews **structure** — an existing feature or the whole `lib/` tree. It
+**reports**, it does not fix.
+
+## When to invoke
+- "Mimariyi kontrol et", "proje konvansiyonlarına uyuyor mu", "şu feature uygun mu", "architecture review", "tech-debt audit".
+
+## When NOT to invoke
+- Reviewing a PR/diff before merge → `hata-pr-review`.
+- Building a feature → `hata-feature`.
+- UI token lookup → `hata-style-guide`.
+
+## Inputs (resolve the scope first)
+1. **Feature/folder named** → review just that (e.g. `lib/features/main/home`).
+2. **No scope given** → ask whether to audit a specific feature or the whole `lib/` (whole-repo is large; prefer scoping). Default to the feature(s) most relevant to the user's recent work.
+
+## Passes (merge into one ranked list)
+
+### Pass A — Static analysis (run first, in parallel)
+```bash
+dart analyze <scope>
+dart format --output=none --set-exit-if-changed <scope>
+```
+Surface every analyzer error/warning as a finding (non-negotiable).
+
+### Pass B — Deep conformance (delegate)
+Hand the file list (and, for a feature, its full contents) to the
+[hata-architecture-reviewer](../../agents/hata-architecture-reviewer.md) agent. It
+checks the `@riverpod`+Notifier pattern, `state = copyWith` mutation, Equatable
+`props`/`copyWith` completeness, `ProjectDependencyMixin`/`AppProviderMixin` DI,
+`GetIt.I`-in-view, no-Freezed, view conventions, typed routes, folder/naming, and
+returns severity-ranked findings.
+
+### Pass C — Token/style sweep (grep, confirm in context)
+```bash
+grep -rnE 'EdgeInsets\.(all|symmetric|only)|Colors\.|Color\(0x|Theme\.of\(context\)|BorderRadius\.circular\(|GetIt\.I|@freezed|extends StatefulWidget' <scope> --include='*.dart' \
+  | grep -vE '\.g\.dart|\.freezed\.dart' || echo "no obvious violations"
+```
+A hit is a smell, not proof — a `Color(0x..)` in a theme/`ColorsCustom` file is allowed; in a view it is a blocker. Also flag hardcoded UI strings that should be `LocaleKeys.*.tr()`.
+
+## Severity rubric
+Same as the reviewer agent: **error** (CLAUDE.md rule break — `GetIt.I` in view, Freezed, direct VM mutation, hardcoded color/EdgeInsets in view, plain `StatefulWidget`, field missing from `props`/`copyWith`), **warning** (logic in view, no decomposition, raw `Text`+`TextStyle`, hardcoded string, wrong structure), **info** (nits).
+
+## Output contract
+```
+## Architecture review: <scope> — <N blocker, N warning, N info>
+
+### 🔴 Blockers
+- [<file>:<line>](<file>#L<line>) — <what & CLAUDE.md section>. Fix: <concrete fix>.
+
+### 🟡 Warnings
+- [<file>:<line>](<file>#L<line>) — <issue>. Fix: <concrete fix>.
+
+### 🔵 Suggestions
+- [<file>:<line>](<file>#L<line>) — <nit>.
+
+### ✅ Conforms
+- <what the code already does right>.
+
+### Verdict
+**<HEALTHY | NEEDS WORK>** — <one sentence>. <blocker count> must-fix.
+```
+Rules: every finding cites a real `file:line`; concrete fixes; de-dup across passes (report once at highest severity); omit empty sections but keep **Verdict**. Do not edit files unless the user explicitly asks afterward (then route fixes through `hata-feature`).

--- a/.claude/skills/hata-feature/SKILL.md
+++ b/.claude/skills/hata-feature/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: hata-feature
+description: End-to-end scaffold for a new life_client Flutter feature following project conventions from CLAUDE.md — Riverpod @riverpod ViewModel + Equatable state (no Freezed), ConsumerStatefulWidget view + mixin, ProjectDependencyMixin/AppProviderMixin DI, go_router typed routes, and the styling token rules (PagePadding, EmptyBox, CustomRadius, ColorsCustom, context.general.colorScheme, GeneralButtonV2, LocaleKeys.tr). Use when the user asks to add or refactor a feature, e.g. "yeni feature ekleyelim", "şu sayfayı projeye göre yaz", "viewmodel + state + view kur", "scaffold a new feature under lib/features".
+---
+
+# life_client Feature Scaffold
+
+Single workflow for building a feature in this repo, enforcing the conventions in
+[CLAUDE.md](../../../CLAUDE.md). This skill is **convention-enforcing**, not
+exploratory — if the user asks "what is X", point them to CLAUDE.md. Only run when
+there is real scaffolding/refactoring to do.
+
+> All rules (architecture, state, DI, styling, l10n) live in CLAUDE.md and are not
+> repeated here. Every generated file must satisfy them or the lints reject it.
+
+## When to invoke
+- Add a new feature under `lib/features/<feature>/` (or `lib/features/sub_feature/<feature>/`).
+- Refactor an existing feature to match conventions.
+- "scaffold viewmodel + state + view + (service) for X".
+- Trigger (TR/EN): "yeni feature ekleyelim", "şu sayfayı projeye göre yaz",
+  "viewmodel + state + view kur", "feature iskeleti çıkar", "scaffold a feature".
+
+## When NOT to invoke
+- Pure UI/token question → `hata-style-guide`.
+- Reviewing changes → `hata-pr-review` / `hata-architecture-review`.
+- Working a GitHub issue end-to-end → `hata-issue`.
+- A one-line bug fix in an existing file → just edit it; don't scaffold.
+
+## Inputs (ask once, up front, if missing)
+1. **Feature name** (snake_case, e.g. `chain_store`, `withdraw`).
+2. **Parent group** — top-level `lib/features/<name>/` or `lib/features/sub_feature/<name>/`. Default: top-level.
+3. **Backend?** — does it read/write Firestore? If yes we add model + queries via `firebaseService`; if no, omit.
+4. **Responsive?** — any per-size variants. Default: standard.
+
+If the user already answered in prose, do not re-ask.
+
+## Execution plan (5 phases, stop after each)
+
+### Phase 1 — Plan
+1. Confirm the 4 inputs.
+2. Lay out the directory:
+   ```
+   lib/features/<feature>/
+   ├── provider/
+   │   ├── <feature>_view_model.dart
+   │   ├── <feature>_view_model.g.dart   # generated
+   │   └── <feature>_state.dart
+   └── view/
+       ├── <feature>_view.dart
+       ├── mixin/ <feature>_view_mixin.dart   # if initState/dispose logic needed
+       └── widget/                            # if 3+ private widgets
+   ```
+3. Identify reusable widgets in [lib/product/widget/](../../../lib/product/widget/) to consume instead of re-implementing (buttons, cards, shimmer, inputs, titles).
+4. Output the plan before writing code.
+
+### Phase 2 — Data layer (skip if no backend)
+- Model: `*_model.dart` with `json_serializable` (or reuse a `life_shared` model). For non-trivial JSON delegate to the `flutter-network-generator` / `flutter-implement` skill if available.
+- Reads/writes go through `firebaseService` (from `ProjectDependencyMixin`) — build `Query`/`CollectionReference` in the ViewModel, as in [home_view_model.dart](../../../lib/features/main/home/provider/home_view_model.dart).
+- Run codegen (Phase 5).
+
+### Phase 3 — State + ViewModel
+1. **State** (`<feature>_state.dart`): `final class XState extends Equatable`, all fields `final` with defaults, full `props`, manual `copyWith`. Include explicit `isFetching`/`isError` flags for async. Pattern: [home_state.dart](../../../lib/features/main/home/provider/home_state.dart).
+2. **ViewModel** (`<feature>_view_model.dart`): `@riverpod final class XViewModel extends _$XViewModel with ProjectDependencyMixin`, `build()` returns initial state, methods mutate via `state = state.copyWith(...)`. Pattern: [place_detail_view_model.dart](../../../lib/features/details/view_model/place_detail_view_model.dart).
+3. Never swallow exceptions — set `isError: true`. Never assign VM fields directly.
+
+### Phase 4 — Presentation
+1. **View** (`<feature>_view.dart`): `ConsumerStatefulWidget`; state mixes `AppProviderMixin<XView>` + feature mixin. `ref.watch(xViewModelProvider)`; conditional render error → shimmer → content.
+2. **Mixin**: owns `initState`/`dispose`/side effects.
+3. **Styling**: `context.general.colorScheme.*`, `PagePadding.*`, `EmptyBox.*`/`VerticalSpace.*`, `CustomRadius.*`, `GeneralButtonV2`, semantic title widgets — never raw `EdgeInsets`/hex/`Text`+`TextStyle`. All strings via `LocaleKeys.*.tr()`.
+4. **Routing**: if a route is needed, add a `@TypedGoRoute` entry in [app_router.dart](../../../lib/product/navigation/app_router.dart) and run codegen.
+
+### Phase 5 — Quality gate (run in parallel)
+```bash
+flutter pub run build_runner build --delete-conflicting-outputs
+dart analyze lib/features/<feature>
+dart format lib/features/<feature>
+```
+If translations were added, run the `lang` script. Add unit/widget tests for non-trivial logic if the project has a test setup.
+
+## Anti-patterns (auto-reject — fix before output)
+- `@freezed` / `with _$X` / `.freezed.dart` — this repo uses Equatable + copyWith.
+- Direct VM field mutation or `setState` for VM state instead of `state = state.copyWith(...)`.
+- `GetIt.I` inside a view file (use the mixins).
+- Plain `StatefulWidget` instead of `ConsumerStatefulWidget`.
+- `Color(0x..)` / `Colors.<name>` / `Theme.of(context)` in a view.
+- Raw `EdgeInsets.*` / hardcoded pixels / `BorderRadius.circular(<int>)`.
+- Hardcoded UI strings (use `LocaleKeys.*.tr()`).
+- Field missing from `props` or `copyWith`.
+- Narration / section-divider comments.
+
+## Output contract
+- One sentence per file created/modified, with clickable links: `[x_view_model.dart](lib/features/<feature>/provider/x_view_model.dart)`.
+- One line on the next manual step (run codegen, register route, add translations).
+- One line on tests still needed, if any. Nothing else.

--- a/.claude/skills/hata-issue/SKILL.md
+++ b/.claude/skills/hata-issue/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: hata-issue
+description: Take a GitHub issue from VB-CORE/life_client, fetch it with gh, split it into atomic tasks, locate the right code under lib/features, build a per-task plan, and drive the fix using project conventions (delegates real scaffolding to hata-feature, deep checks to hata-architecture-review). Use when the user gives an issue number or github.com/VB-CORE/life_client/issues/<n> URL and asks to work it, e.g. "şu issue'yu al ve çöz", "bu issue'daki bug'ları düzelt", "issue 42'yi gh ile çek planını çıkar", "fix the bugs in this issue", "issue'yu projeye göre çöz".
+---
+
+# life_client Issue → Plan → Fix
+
+Turns a GitHub issue into a worked solution **the life_client way**: fetch with
+`gh`, break the body into atomic tasks, point each at the real code, then drive each
+fix under [CLAUDE.md](../../../CLAUDE.md) conventions. This skill **plans and
+routes**; it does not invent conventions.
+
+Repo: `VB-CORE/life_client`. Default branch: `main`. Uses plain `gh`/`git` (no
+helper scripts). Prereq: `gh auth status`.
+
+## When to invoke
+- User gives an issue number/URL and asks to work / fix / plan it.
+- Trigger (TR/EN): "şu issue'yu al", "issue'daki bug'ları çöz", "issue N'i gh ile çek", "fix this issue", "plan the issue", "issue'yu projeye göre çöz".
+
+## When NOT to invoke
+- Greenfield feature with no issue → `hata-feature` directly.
+- Reviewing a PR/diff → `hata-pr-review`.
+- Whole-codebase structure audit → `hata-architecture-review`.
+
+## Step 1 — Fetch + decompose the issue
+```bash
+gh issue view <n> --repo VB-CORE/life_client --json title,body,labels,comments
+# a pasted URL also works:
+gh issue view https://github.com/VB-CORE/life_client/issues/<n> --json title,body,labels
+```
+Split the body into **atomic tasks**:
+- If the body has `- [ ]` / `- [x]` checkboxes, each is a task (note done state).
+- Otherwise split on numbered/bulleted items; if it is one paragraph, treat it as a single task.
+- For each task record: a one-line summary, any attachment URLs (usually bug screen-recordings — you **cannot** view these; flag them), and the keywords/nouns to grep.
+
+Present a short task table to the user before touching code.
+
+## Step 2 — Locate the real code
+For the chosen task:
+1. Grep `lib/features/` (and `lib/product/`) for the symptom — a label, a button text, a viewmodel/state name.
+2. **TR UI strings are rarely hardcoded** — search the locale keys (`assets/translations/{tr,en}.json`, `locale_keys.g.dart`) for the Turkish phrase, then grep the resulting key in widgets. Mind smart quotes (`"` `"`) and Turkish chars.
+3. Confirm the exact file (view / viewmodel / state / model) before editing. Most issue tasks are bugs in **one** existing file, not new features.
+
+## Step 3 — Plan per task (before editing)
+- The task (one line) + the file(s) it touches.
+- Root-cause hypothesis (e.g. "button enables at 9 digits because the validator checks `>= 9` not `== 10`").
+- The fix in project terms (which viewmodel/state/widget changes, which CLAUDE.md rule applies).
+- Whether it's a one-liner (edit directly) or needs scaffolding (route through `hata-feature`).
+
+## Step 4 — Drive the fix
+- **Bug in an existing file** (the common case): edit directly, honoring CLAUDE.md (`state = copyWith`, tokens, no `GetIt.I` in view, `LocaleKeys.tr`). Do **not** scaffold a new feature.
+- **Needs new viewmodel/state/view/service**: hand off to [hata-feature](../hata-feature/SKILL.md) and follow its 5-phase plan.
+- Keep unrelated tasks as **separate commits** — one issue is often a batch of unrelated bugs.
+
+## Step 5 — Quality gate
+```bash
+dart analyze lib/features/<touched-feature>
+dart format lib/features/<touched-feature>
+flutter pub run build_runner build --delete-conflicting-outputs   # only if a generated file changed
+```
+Optionally self-review the diff with `hata-pr-review` before handing back.
+
+## Step 6 — Report back (ask before pushing to GitHub)
+```bash
+gh issue view <n> --repo VB-CORE/life_client          # re-read current state
+gh issue comment <n> --repo VB-CORE/life_client --body "Task N fixed in <branch>"
+```
+
+## Output contract
+- A task table at the start.
+- Per task worked: file(s) touched (clickable links) + one-line root cause.
+- What still needs manual verification (the bug videos can't be watched here).
+- Branch suggestion: `feature/#<n>` (or `fix/#<n>`).
+
+## Gotchas
+- **Attachment videos can't be viewed** — plan from text + code only; tell the user which tasks hinge on a video you couldn't see.
+- **One issue ≠ one fix** — a batch issue is many unrelated bugs; work them as separate tasks/commits, don't try to "solve the issue" in one edit.
+- **TR text + smart quotes** — search locale keys, not the literal Turkish phrase in widgets.
+- **No `- [ ]` checkboxes** → read the whole body and treat it as one (or a few) task(s).
+
+## Troubleshooting
+| Symptom | Fix |
+|---|---|
+| `gh ... HTTP 404` | Wrong repo or not authed. `gh auth status`; pass `--repo VB-CORE/life_client`. |
+| Can't find the code for a task | Grep the summary nouns under `lib/features/`; for UI text, go via `assets/translations` keys. |

--- a/.claude/skills/hata-pr-review/SKILL.md
+++ b/.claude/skills/hata-pr-review/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: hata-pr-review
+description: Review a life_client change set (working diff, a branch vs main, or a GitHub PR) against the project's CLAUDE.md conventions, then produce one severity-ranked review with file:line findings and concrete fixes. Combines a static-analysis pass, a styling/token pass, and an architecture-conformance pass delegated to the hata-architecture-reviewer agent. Use when the user asks to review changes/a diff/a PR before merge, e.g. "bu PR'ı incele", "şu diff'i projeye göre review et", "pr review yap", "merge'e hazır mı", "review my changes against conventions".
+---
+
+# life_client PR Review
+
+Single entry point for reviewing a change set in this repo against
+[CLAUDE.md](../../../CLAUDE.md). It **reviews, it does not fix** — only apply fixes
+if the user explicitly asks afterward (then route through `hata-feature`).
+
+Repo: `VB-CORE/life_client`. Default branch: `main`.
+
+## When to invoke
+- "Review this PR / diff / branch", "merge'e hazır mı".
+- Trigger (TR/EN): "bu PR'ı incele", "şu diff'i review et", "pr review yap", "review my changes against conventions", "code review this branch".
+
+## When NOT to invoke
+- Building/scaffolding a feature → `hata-feature`.
+- Working a GitHub issue end-to-end → `hata-issue`.
+- Auditing whole-codebase structure (not a diff) → `hata-architecture-review`.
+
+## Inputs (resolve the review target first, in order)
+1. **Explicit PR** — number or `github.com/VB-CORE/life_client/pull/<n>` → `gh pr diff <n>` (+ `gh pr view <n>` for context/description).
+2. **Branch** — user names a branch → `git diff main...<branch>`.
+3. **Default** — no target → working set: `git diff` + `git diff --staged`, falling back to `git diff main...HEAD` if the tree is clean.
+
+Review **only changed lines + the files they touch**. Never audit the whole repo. If the diff is empty, say so and stop. Prereq for PR mode: `gh auth status`.
+
+## Passes (merge into one ranked list)
+
+### Pass A — Static analysis (run first, in parallel)
+```bash
+dart analyze <changed dirs>
+dart format --output=none --set-exit-if-changed <changed .dart files>
+```
+Surface every analyzer error/warning + format drift. Non-negotiable.
+
+### Pass B — Architecture conformance (delegate)
+Hand the changed file list + the diff to the
+[hata-architecture-reviewer](../../agents/hata-architecture-reviewer.md) agent so
+it reviews changed lines (not the whole tree): `@riverpod`+Notifier, `state =
+copyWith`, Equatable `props`/`copyWith`, DI mixins, `GetIt.I`-in-view, no-Freezed,
+view conventions, typed routes, structure.
+
+### Pass C — Styling & token rules (grep the diff, confirm in context)
+| Anti-pattern | Required fix |
+|---|---|
+| `EdgeInsets.all/symmetric/only(` | `PagePadding.*` |
+| hardcoded pixel in `SizedBox` / `BorderRadius.circular(<int>)` | `EmptyBox`/`VerticalSpace` / `CustomRadius.*` |
+| `Color(0x..)` / `Colors.<name>` / `Theme.of(context)` (in a view) | `context.general.colorScheme.*` / `ColorsCustom` |
+| raw `Text(...,style: TextStyle(...))` | semantic title widget |
+| hardcoded UI string | `LocaleKeys.*.tr()` |
+| `GetIt.I` in a view | `ProjectDependencyMixin` / `AppProviderMixin` |
+| `@freezed` / `with _$X` | Equatable + manual `copyWith` |
+| `extends StatefulWidget` (not Consumer) | `ConsumerStatefulWidget` |
+
+Fast first sweep:
+```bash
+git diff main...HEAD -- '*.dart' | grep -nE \
+  'EdgeInsets\.(all|symmetric|only)|Colors\.|Color\(0x|Theme\.of\(context\)|BorderRadius\.circular\(|GetIt\.I|@freezed|extends StatefulWidget' \
+  || echo "no obvious token violations"
+```
+Grep is a smell test — a `Color(0x..)` inside a theme/`ColorsCustom` file is allowed; inside a view it is a blocker.
+
+## Severity rubric
+- **error (blocker)** — analyzer error, or a CLAUDE.md rule break (hardcoded color/EdgeInsets in view, `GetIt.I` in view, Freezed, direct VM mutation, plain `StatefulWidget`, field missing from `props`/`copyWith`, `mounted` not checked after an `await` touching context).
+- **warning** — convention deviation worth fixing now (logic in view, 50+ line widget not decomposed, missing `copyWith`, hardcoded string).
+- **info** — nits (naming, redundant import, missing `const`, double quotes).
+
+## Output contract (one consolidated review, no preamble)
+```
+## PR review: <target> — <N blocker, N warning, N info>
+
+### 🔴 Blockers
+- [<file>:<line>](<file>#L<line>) — <what & which rule>. Fix: <concrete fix>.
+
+### 🟡 Warnings
+- [<file>:<line>](<file>#L<line>) — <issue>. Fix: <concrete fix>.
+
+### 🔵 Suggestions
+- [<file>:<line>](<file>#L<line>) — <nit>.
+
+### ✅ Looks good
+- <1–3 things done right, so the author keeps them>.
+
+### Verdict
+**<APPROVE | CHANGES REQUESTED>** — <one sentence>. <blocker count> must-fix.
+```
+Rules: every finding cites a real `file:line` (no line → not a finding); concrete fixes (name the replacement); `CHANGES REQUESTED` if ≥1 blocker else `APPROVE`; de-dup across passes (report once at highest severity); omit empty sections but keep **Verdict**; never modify files unless asked.
+
+## Posting back (only if the user asks)
+`gh pr review <n> --comment --body-file <tmp>` (or `--request-changes` when there are blockers). Never post without being asked.

--- a/.claude/skills/hata-style-guide/SKILL.md
+++ b/.claude/skills/hata-style-guide/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: hata-style-guide
+description: Design-system reference for life_client UI — the project's colors (ColorsCustom + context.general.colorScheme), typography (Roboto + semantic title widgets), spacing/radius tokens (PagePadding, EmptyBox, VerticalSpace, CustomRadius, WidgetSizes), reusable widget catalog (GeneralButtonV2, cards, inputs, dialogs), light/dark/system theming and easy_localization. Use when building or adjusting any UI and you need the project's tokens/components, e.g. "renkleri/fontları projeye göre kullan", "bu butonu projeye göre yaz", "style guide", "tema token'ları", "make this UI match the design system".
+---
+
+# life_client Style Guide
+
+Convention reference for building UI the life_client way. The authoritative rules
+live in [CLAUDE.md §6–§7](../../../CLAUDE.md); this skill is the quick lookup +
+checklist when writing widgets. **Enforce, don't invent** — if a token is missing,
+add it to the theme/token file, not the call site.
+
+## When to invoke
+- Writing or restyling any screen/widget and you need the right token/component.
+- "bu UI'ı tasarım sistemine uydur", "renkleri/fontları projeye göre kullan",
+  "style guide", "hangi spacing/radius", "match the design system".
+
+## When NOT to invoke
+- Scaffolding a whole feature (viewmodel+state+view) → `hata-feature`.
+- Reviewing a diff → `hata-pr-review`.
+
+## Colors
+- **Always** `context.general.colorScheme.*` — `primary`, `secondary`, `surface`, `onSurface`, `error`, `onTertiary`, ...
+- Fixed palette: `ColorsCustom` ([colors_custom.dart](../../../lib/product/utility/decorations/colors_custom.dart)) — `sambacus` (0xFF101A2A), `endless` (red), `braziliante` (green), `brandeisBlue`, `royalPeacock`, `lightGray`, `warmGrey`, `darkGray`, `softGray`, `imperilRead`.
+- Helpers: `ColorCommon` ([color_common.dart](../../../lib/product/common/color_common.dart)) — `whiteAndBlackForTheme`, `blackAndWhiteForTheme` for theme-aware fills.
+- ❌ `Color(0x..)` / `Colors.<name>` / `Theme.of(context)` in a view. Need a new color? Add it to `ColorsCustom` or the theme.
+
+## Typography
+- Roboto via `GoogleFonts.robotoTextTheme` set on the theme ([application_theme.dart](../../../lib/product/init/application_theme.dart)).
+- Use **semantic text widgets**, not raw `Text` + `TextStyle`:
+  - `GeneralBodyTitle` — titleMedium w600 (headings)
+  - `GeneralContentTitle` — titleLarge w500 (section titles)
+  - `GeneralContentSubTitle` — bodyMedium w500 (descriptions)
+  - `GeneralContentSmallTitle`, `GeneralSubTitle`, `GeneralBigTitle`
+- Icons: `AppIcons` (Material) + `FontAwesomeIcons.*`; sizes via `AppIconsSizes` (xSmall..xLarge).
+
+## Spacing & radius tokens
+- Padding: `PagePadding.*` — `defaultPadding()`, `horizontalSymmetric()`, `vertical12Symmetric()`, ... ❌ raw `EdgeInsets`.
+- Vertical gaps: `EmptyBox.*` (`xSmallHeight` 4, `smallHeight` 8, `middleHeight` 16, `largeHeight` 24) or `VerticalSpace.*`.
+- Scale: `WidgetSizes.spacingXs … spacingXxl*` (life_shared). ❌ hardcoded pixels.
+- Radius: `CustomRadius.*` ([custom_radius.dart](../../../lib/product/utility/decorations/custom_radius.dart)) — `small` 8 / `medium` 12 / `large` 16 / `extraLarge` 24 / `xxLarge` 32. ❌ `BorderRadius.circular(<int>)`.
+- Durations: `DurationConstant` (`durationLow` 500ms, `durationNormal` 1s, `durationMedium` 2s).
+- Shadows: `GeneralShadow.*`; box decorations in [box_decorations.dart](../../../lib/product/utility/decorations/box_decorations.dart).
+
+## Reusable components (consume, don't re-implement)
+Browse [lib/product/widget/](../../../lib/product/widget/) (each category has an `index.dart`):
+- Buttons: `GeneralButtonV2.active()` / `.async()`, `IconTitleButton`, `AppbarIconButton`, `FavoritePlaceButton`, `SocialMediaButton`.
+- Cards: `GeneralPlaceCard`, `AdvertisePlaceCard`, `NewsCard`, `DeveloperProfileCard`.
+- Inputs: `CustomTextFormField`, `CustomTextFormSelectionField`, `PhoneTextFormField`, `ValidatorTextFormField`.
+- Layout/feedback: `GeneralScaffold` (auto horizontal padding), `GeneralNotFoundWidget`, shimmer placeholders, `GeneralTextDialog`/`GeneralIconTextDialog`, `GeneralCheckBox`, `GeneralExpansionTile`.
+
+## Theming
+- light / dark / system driven by `AppProviderState.theme`; `MaterialApp.router` supplies both `theme` and `darkTheme`. Card theme: elevation 2, radius 12 (`CustomRadius.medium`); inputs filled, radius 12.
+- New colors must read correctly in both modes — prefer `colorScheme` roles over fixed palette where the value should flip.
+
+## Localization
+- `LocaleKeys.*.tr()` ([locale_keys.g.dart](../../../lib/product/init/language/locale_keys.g.dart)); files under `assets/translations/{tr,en}.json`. ❌ hardcoded UI strings.
+
+## New-screen checklist (every box must pass)
+- [ ] Colors via `context.general.colorScheme.*` / `ColorsCustom` only.
+- [ ] Padding `PagePadding.*`; gaps `EmptyBox`/`VerticalSpace`; no raw pixels/`EdgeInsets`.
+- [ ] Radius `CustomRadius.*`.
+- [ ] Text via semantic title widgets; Roboto theme.
+- [ ] Buttons/inputs/cards reused from `product/widget/`.
+- [ ] Strings via `LocaleKeys.*.tr()`.
+- [ ] Readable in both light & dark.
+
+## "Don't → Do" quick map
+| Don't | Do |
+|---|---|
+| `Color(0xFF101A2A)` / `Colors.blue` | `context.general.colorScheme.*` / `ColorsCustom.*` |
+| `EdgeInsets.all(16)` | `PagePadding.defaultPadding()` |
+| `SizedBox(height: 16)` | `EmptyBox.middleHeight()` / `VerticalSpace.standard()` |
+| `BorderRadius.circular(12)` | `CustomRadius.medium` |
+| `Text('Kaydet', style: TextStyle(...))` | `GeneralBodyTitle(value: LocaleKeys.button_save.tr())` |
+| `ElevatedButton(...)` | `GeneralButtonV2.active(...)` |
+| hardcoded `'Yer bulunamadı'` | `LocaleKeys.notification_placeNotFound.tr()` |
+
+This skill is a reference, not a builder. To actually scaffold UI + logic, use
+`hata-feature`.

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,11 @@ emulator-data/
 # IDE and Editor specific files
 .vscode/
 .idea/
-.claude/
+# Claude: share team skills/agents in the repo, ignore only local settings
+.claude/*
+!.claude/skills/
+!.claude/agents/
+.claude/settings.local.json
 .idx/
 .cursor/
 *.code-workspace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,235 @@
+# CLAUDE.md — life_client Konvansiyonları
+
+> Bu dosya, projede iş yapan herkes (ve Claude) için **tek doğru kaynaktır**.
+> `.claude/skills/*` ve `.claude/agents/*` bu kurallara referans verir; kuralları
+> tekrar etmez. Bir konvansiyon değişecekse önce burada değişir.
+
+Proje: Hatay **life_client** — Flutter + Firebase mobil uygulaması.
+Stack: Flutter, `flutter_riverpod` (v3, `@riverpod` codegen), `get_it`, `go_router` +
+`go_router_builder`, Firebase (Firestore/Functions/Messaging), `hive_ce`,
+`easy_localization`, `very_good_analysis`.
+
+---
+
+## 1. Mimari
+
+**Feature-first + paylaşılan `product/` katmanı.**
+
+```
+lib/
+├── core/            # DI (project_dependency*.dart), düşük seviye altyapı
+├── features/        # ana feature'lar (her biri kendi viewmodel+view)
+│   └── sub_feature/ # ikincil/modüler feature'lar
+├── sub_feature/     # uygulama kabuğu (main_tab, onboard, ...)
+├── product/         # paylaşılan: navigation, init, widget, utility, model
+└── main.dart
+```
+
+Bir feature'ın iç yapısı:
+
+```
+lib/features/<feature>/
+├── provider/                 # (veya view_model/) state mantığı
+│   ├── <feature>_view_model.dart
+│   ├── <feature>_view_model.g.dart    # üretilen (commit edilir)
+│   └── <feature>_state.dart
+├── view/
+│   ├── <feature>_view.dart
+│   ├── mixin/                # initState/dispose/iş mantığı mixin'leri
+│   └── widget/               # parçalanmış alt widget'lar
+```
+
+İsimlendirme: `*_view_model.dart`, `*_state.dart`, `*_view.dart`, mixin `*_mixin.dart`,
+model `*_model.dart`. Sınıf isimleri `XViewModel`, `XState`, `XView`, `XModel`.
+
+---
+
+## 2. State Management — Riverpod `@riverpod` Notifier
+
+**Freezed YOK.** State = `Equatable` + manuel `copyWith()`. Async için `AsyncValue`
+yerine **açık `isLoading` / `isFetching` / `isError` flag'leri**.
+
+### ViewModel
+
+```dart
+part 'home_view_model.g.dart';
+
+@riverpod
+final class HomeViewModel extends _$HomeViewModel with ProjectDependencyMixin {
+  @override
+  HomeState build() {
+    final categories = ref.read(productProviderState).categoryItems;
+    return HomeState(categories: categories);
+  }
+
+  void changeHomeViewCardType() {
+    state = state.copyWith(isGridView: !state.isGridView);
+  }
+
+  Future<void> fetchStoreModel(String id) async {
+    state = state.copyWith(isFetching: true);
+    final item = await firebaseService.getSingleData<StoreModel>(/* ... */);
+    state = state.copyWith(storeModel: item, isFetching: false, isError: item == null);
+  }
+}
+```
+
+- `@riverpod final class XViewModel extends _$XViewModel with ProjectDependencyMixin`.
+- `build()` initial state'i kurar (provider/cache'ten okuyarak).
+- Mutasyon **daima** `state = state.copyWith(...)` ile. Asla doğrudan alan ataması yok.
+- İstisnayı yutma; hata flag'ine çevir (`isError: true`).
+
+Referans: [home_view_model.dart](lib/features/main/home/provider/home_view_model.dart),
+[place_detail_view_model.dart](lib/features/details/view_model/place_detail_view_model.dart).
+
+### State
+
+```dart
+final class HomeState extends Equatable {
+  const HomeState({
+    required this.categories,
+    this.isGridView = false,
+    this.isLoading = false,
+  });
+
+  final List<CategoryModel> categories;
+  final bool isGridView;
+  final bool isLoading;
+
+  @override
+  List<Object> get props => [categories, isGridView, isLoading];
+
+  HomeState copyWith({
+    List<CategoryModel>? categories,
+    bool? isGridView,
+    bool? isLoading,
+  }) {
+    return HomeState(
+      categories: categories ?? this.categories,
+      isGridView: isGridView ?? this.isGridView,
+      isLoading: isLoading ?? this.isLoading,
+    );
+  }
+}
+```
+
+- `final class XState extends Equatable`, tüm alanlar `final`, varsayılan değerli.
+- `props` tüm alanları içerir. `copyWith` manuel.
+
+Referans: [home_state.dart](lib/features/main/home/provider/home_state.dart).
+
+---
+
+## 3. Dependency Injection — GetIt + Riverpod hibrit
+
+- Servisler/global provider'lar GetIt'te kurulur: [project_dependency.dart](lib/core/dependency/project_dependency.dart),
+  `ApplicationInit.start()` içinde `ProjectDependency.setup()`.
+- **ViewModel içinde** servise erişim → `ProjectDependencyMixin`
+  ([project_dependency_mixin.dart](lib/core/dependency/project_dependency_mixin.dart)):
+  `firebaseService`, `appProvider`, `productProvider`, `productCache`, `appProviderState`, `productProviderState`.
+- **Widget içinde** global state erişimi → `AppProviderMixin<T>` (ConsumerStatefulWidget) /
+  `AppProviderStateMixin` (ConsumerWidget)
+  ([app_provider_mixin.dart](lib/product/utility/mixin/app_provider_mixin.dart)):
+  `appProvider`, `appState`, `productProvider`, `productState`, `productStateWatch`.
+- **View dosyasında `GetIt.I` çağrısı YASAK.** Daima mixin üstünden.
+
+---
+
+## 4. View
+
+- `ConsumerStatefulWidget` / `ConsumerWidget` (asla düz `StatefulWidget`).
+- State sınıfı `AppProviderMixin<XView>` + feature mixin'leriyle karışır.
+- State'i `ref.watch(xViewModelProvider)` ile izle, aksiyonu
+  `ref.read(xViewModelProvider.notifier).method()` ile çağır.
+- Koşullu render: `isError` → hata widget'ı, yükleniyor → shimmer, dolu → içerik.
+
+```dart
+final class _PlaceDetailViewState extends ConsumerState<PlaceDetailView>
+    with AppProviderMixin<PlaceDetailView>, PlaceDetailViewMixin {
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(placeDetailViewModelProvider);
+    if (state.isError) return Scaffold(body: GeneralNotFoundWidget(...));
+    if (state.isFetching) return const Scaffold(body: PlaceShimmerList());
+    return Scaffold(/* content */);
+  }
+}
+```
+
+---
+
+## 5. Routing — go_router_builder (typed)
+
+`@TypedGoRoute<XRoute>` + `final class XRoute extends GoRouteData with $XRoute`,
+`build()` widget'ı döner. Karmaşık nesne geçişi `$extra` ile. Codegen sonrası
+`app_router.g.dart` (commit edilir). Referans: [app_router.dart](lib/product/navigation/app_router.dart).
+
+---
+
+## 6. Styling (sert kurallar — lint/review reddeder)
+
+### Renk
+- Daima `context.general.colorScheme.*` (primary/secondary/surface/onSurface/...).
+- Sabit palet: `ColorsCustom` ([colors_custom.dart](lib/product/utility/decorations/colors_custom.dart)) —
+  `sambacus`, `endless`, `brandeisBlue`, `lightGray`, `warmGrey`, `royalPeacock`, ...
+- View içinde `Color(0x...)` / `Colors.<name>` / `Theme.of(context)` **yasak** (tema tanım dosyaları hariç).
+- Eksik renk gerekiyorsa çağrı yerine değil, **temaya** ekle.
+
+### Spacing & boyut
+- Padding: `PagePadding.*` (örn. `PagePadding.defaultPadding()`, `vertical12Symmetric()`). Ham `EdgeInsets` yasak.
+- Dikey boşluk: `EmptyBox.*` (`smallHeight`/`middleHeight`/`largeHeight`) veya `VerticalSpace.*`.
+- Ölçek: `WidgetSizes.spacing*` (life_shared). Hardcoded piksel yasak.
+- Responsive: `context.sized.dynamicHeight/Width(...)` (mevcut kullanım).
+
+### Radius
+- `CustomRadius.*` ([custom_radius.dart](lib/product/utility/decorations/custom_radius.dart)):
+  `small`(8) / `medium`(12) / `large`(16) / `extraLarge`(24) / `xxLarge`(32). Ham `BorderRadius.circular(<int>)` yerine bunlar.
+
+### Tipografi
+- Roboto, `GoogleFonts.robotoTextTheme` tema üstünden ([application_theme.dart](lib/product/init/application_theme.dart)).
+- Ham `Text` + manuel `TextStyle` yerine semantic widget'lar: `GeneralBodyTitle`,
+  `GeneralContentTitle`, `GeneralContentSubTitle`, `GeneralContentSmallTitle`.
+
+### Bileşenler
+- Buton: `GeneralButtonV2.active()` / `.async()`. Input: `CustomTextFormField`.
+- Önce [lib/product/widget/](lib/product/widget/) kataloğuna bak; yeniden implement etme.
+
+### Tema
+- light / dark / system → `AppProviderState.theme`. `MaterialApp.router` hem `theme` hem `darkTheme` alır.
+
+---
+
+## 7. Localization
+- `LocaleKeys.*.tr()` (`easy_localization`). Hardcoded UI string **yasak**.
+- Çeviriler `assets/translations/{tr,en}.json`; key üretimi `lang` script'i ile
+  `lib/product/init/language/locale_keys.g.dart`.
+- Not: TR bir metni kodda ararken literal yerine **locale key**'i ara.
+
+---
+
+## 8. Kod kalitesi & codegen
+
+- Lint: `very_good_analysis` ([analysis_options.yaml](analysis_options.yaml)) —
+  `prefer_single_quotes`, `sort_constructors_first`, `always_declare_return_types`,
+  `prefer_const_constructors`, `avoid_print`. Üretilen dosyalar exclude.
+- `final class` tercih edilir; `const` mümkün olan her yerde; trailing comma çok satırlı literallerde.
+- **Yorum politikası**: narration/bölüm-ayracı yorum yok. Sadece public API'de `///`, ve yalnızca aşikar
+  olmayan mantıkta satır içi yorum. Kod isimlendirmeyle kendini anlatır.
+- Codegen: `flutter pub run build_runner build --delete-conflicting-outputs`
+  (veya pubspec script'leri: `dartBuild`, `watch`, `general`). l10n: `lang` script'i.
+
+---
+
+## 9. Skill'ler
+
+İş tipine göre `.claude/skills/`:
+
+| İş | Skill |
+|---|---|
+| Yeni feature / sayfa (viewmodel+state+view) | `hata-feature` |
+| Tema/renk/font/spacing — UI tasarım sistemi | `hata-style-guide` |
+| Genel mimari uygunluk kontrolü | `hata-architecture-review` |
+| PR / diff / branch review | `hata-pr-review` |
+| GitHub issue → plan → çözüm | `hata-issue` |
+
+Derin mimari/konvansiyon denetimi `hata-architecture-reviewer` subagent'ına devredilir.


### PR DESCRIPTION
This pull request adds detailed skill and agent documentation for the `life_client` Flutter project's Claude-based automation and review tools. The main focus is on codifying the project's architecture, review, and scaffolding conventions in markdown files for Claude agents and skills. These documents define how automated reviews, feature scaffolding, and issue resolution should be performed to ensure strict adherence to project conventions as described in `CLAUDE.md`.

The most important changes are:

**Architecture and Review Automation:**

* Added `.claude/agents/hata-architecture-reviewer.md`, which describes a deep architecture and convention conformance agent. It defines the rules, severity rubric, and output format for reviewing changed Dart files against `CLAUDE.md` conventions, focusing on state management, DI, view patterns, routing, structure, styling tokens, localization, and lint/style.
* Added `.claude/skills/hata-architecture-review/SKILL.md`, which documents the skill for auditing the overall architecture and convention health of the codebase or a feature. It specifies when to invoke the skill, how to scope reviews, the analysis and review passes, severity rubric, and output contract.
* Added `.claude/skills/hata-pr-review/SKILL.md`, which describes the process for reviewing a PR or diff against project conventions, including static analysis, architecture conformance (delegated to the reviewer agent), styling/token checks, severity rubric, and output format.

**Feature Scaffolding and Issue Workflow:**

* Added `.claude/skills/hata-feature/SKILL.md`, which provides a detailed, phase-based workflow for scaffolding new features or refactoring existing ones according to project conventions. It includes directory structure, state/viewmodel patterns, styling, routing, anti-patterns, and output contracts.
* Added `.claude/skills/hata-issue/SKILL.md`, which outlines the process for taking a GitHub issue, decomposing it into tasks, mapping tasks to code, planning and driving fixes, and reporting back, all while enforcing project conventions and using the appropriate skills for scaffolding or review.