### PR TITLE
feature/home v2 update

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -112,7 +112,9 @@
     "categories": "Categories",
     "places": "Places",
     "search": "Search",
-    "notifications": "Notifications"
+    "notifications": "Notifications",
+    "allCategory": "All",
+    "placesUpper": "PLACES"
   },
   "message": {
     "emptySearch": "No Results Found",
@@ -303,6 +305,12 @@
     "time": {
       "newest": "Newest to oldest",
       "oldest": "Oldest to newest"
+    },
+    "title": "Sort",
+    "applied": "Sorting updated",
+    "alpha": {
+      "aToZ": "A → Z",
+      "zToA": "Z → A"
     }
   },
   "utils": {
@@ -311,7 +319,10 @@
   "advertisementBoard": {
     "openUrl": "Open Url",
     "launchUrlError": "An error occurred when launch url",
-    "shareAdvertisementSubject": "Visit advertisement owner: {}"
+    "shareAdvertisementSubject": "Visit advertisement owner: {}",
+    "houseAdTitle": "YOU CAN ADVERTISE HERE",
+    "houseAdSubtitle": "Reach local businesses · Contact: medya@hatayiyasat.app",
+    "contactUs": "Get in touch"
   },
   "chain_stores": {
     "title": "Container Bazaars",
@@ -379,5 +390,23 @@
       "noDescription": "No description"
     },
     "shareSubject": "Keep 'Hatay Yaşat' with us!"
+  },
+  "filter": {
+    "title": "Filter",
+    "clear": "Clear",
+    "categories": "Categories",
+    "others": "Other",
+    "openNow": "Open now",
+    "favoritesOnly": "In my favorites",
+    "districts": "Districts",
+    "nearYou": "Near you",
+    "searchDistrict": "Search district",
+    "selectedCount": "{}/{} selected",
+    "showResults": "Show {} results",
+    "noResults": "No results, loosen filters",
+    "categoryCountLabel": "{} categories",
+    "districtCountLabel": "{} districts",
+    "openShort": "open",
+    "favoritesShort": "favorites"
   }
 }

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -112,7 +112,9 @@
     "categories": "Kategoriler",
     "places": "Mekanlar",
     "search": "Ara",
-    "notifications": "Bildirimler"
+    "notifications": "Bildirimler",
+    "allCategory": "Tümü",
+    "placesUpper": "MEKAN"
   },
   "message": {
     "emptySearch": "Sonuç Bulunamadı",
@@ -303,6 +305,12 @@
     "time": {
       "newest": "Yeniden eskiye",
       "oldest": "Eskiden yeniye"
+    },
+    "title": "Sırala",
+    "applied": "Sıralama güncellendi",
+    "alpha": {
+      "aToZ": "A → Z",
+      "zToA": "Z → A"
     }
   },
   "utils": {
@@ -311,7 +319,10 @@
   "advertisementBoard": {
     "openUrl": "Linki Aç",
     "launchUrlError": "Link açılırken bir hata meydana geldi",
-    "shareAdvertisementSubject": "Bu reklam vereni ziyaret et: {}"
+    "shareAdvertisementSubject": "Bu reklam vereni ziyaret et: {}",
+    "houseAdTitle": "BU ALANA REKLAM VEREBİLİRSİNİZ",
+    "houseAdSubtitle": "Esnafına ulaş · İletişim: medya@hatayiyasat.app",
+    "contactUs": "İletişime geç"
   },
   "chain_stores": {
     "title": "Konteyner Çarşılar",
@@ -379,5 +390,23 @@
       "noDescription": "Açıklama yok"
     },
     "shareSubject": "Hatıralar Hatay'ı Yaşat ile Yaşıyor!"
+  },
+  "filter": {
+    "title": "Filtre",
+    "clear": "Temizle",
+    "categories": "Kategoriler",
+    "others": "Diğer",
+    "openNow": "Şu an açık olanlar",
+    "favoritesOnly": "Favorilerimde olanlar",
+    "districts": "İlçeler",
+    "nearYou": "Sana yakın",
+    "searchDistrict": "İlçe ara",
+    "selectedCount": "{}/{} seçili",
+    "showResults": "{} sonucu göster",
+    "noResults": "Sonuç yok, filtreyi gevşet",
+    "categoryCountLabel": "{} kategori",
+    "districtCountLabel": "{} ilçe",
+    "openShort": "açık",
+    "favoritesShort": "favori"
   }
 }

--- a/lib/features/main/home/provider/home_state.dart
+++ b/lib/features/main/home/provider/home_state.dart
@@ -8,20 +8,50 @@ final class HomeState extends Equatable {
     this.isGridView = false,
     this.sortingType = SortingTypes.newest,
     this.isLoading = false,
+    this.categoryValues = const {},
+    this.townCodes = const {},
+    this.openNow = false,
+    this.favoritesOnly = false,
   });
 
   final List<CategoryModel> categories;
   final bool isGridView;
   final SortingTypes sortingType;
 
-  /// if true, the data is loading for new sorting type
+  /// Selected category [CategoryModel.value]s; empty = all categories.
+  final Set<int> categoryValues;
+
+  /// Selected town codes; empty = all districts.
+  final Set<int> townCodes;
+
+  /// Client-side: only currently-open places.
+  final bool openNow;
+
+  /// Client-side: only favorited places.
+  final bool favoritesOnly;
+
+  /// if true, the data is loading for a new sorting/filter selection
   final bool isLoading;
+
+  bool get hasActiveFilters =>
+      categoryValues.isNotEmpty ||
+      townCodes.isNotEmpty ||
+      openNow ||
+      favoritesOnly;
+
+  /// Whether the place list must be filtered in memory (open/favorites).
+  bool get hasClientFilters => openNow || favoritesOnly;
+
   @override
   List<Object> get props => [
         categories,
         isGridView,
         sortingType,
         isLoading,
+        categoryValues,
+        townCodes,
+        openNow,
+        favoritesOnly,
       ];
 
   HomeState copyWith({
@@ -29,12 +59,20 @@ final class HomeState extends Equatable {
     bool? isGridView,
     SortingTypes? sortingType,
     bool? isLoading,
+    Set<int>? categoryValues,
+    Set<int>? townCodes,
+    bool? openNow,
+    bool? favoritesOnly,
   }) {
     return HomeState(
       categories: categories ?? this.categories,
       isGridView: isGridView ?? this.isGridView,
       sortingType: sortingType ?? this.sortingType,
       isLoading: isLoading ?? this.isLoading,
+      categoryValues: categoryValues ?? this.categoryValues,
+      townCodes: townCodes ?? this.townCodes,
+      openNow: openNow ?? this.openNow,
+      favoritesOnly: favoritesOnly ?? this.favoritesOnly,
     );
   }
 }

--- a/lib/features/main/home/provider/home_view_model.dart
+++ b/lib/features/main/home/provider/home_view_model.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/core/dependency/project_dependency_mixin.dart';
@@ -31,21 +34,46 @@ final class HomeViewModel extends _$HomeViewModel with ProjectDependencyMixin {
 
   Query<StoreModel?> fetchApprovedCollectionQuery() {
     final selectedCity = ref.watch(productProviderState).selectedCity;
-    final query = firebaseService
-        .collectionReference(
-          CollectionPaths.approvedApplications,
-          StoreModel.empty(),
-        )
-        .where(
-          FirebaseQueryItems.cityId.name,
-          isEqualTo: selectedCity.documentId,
-        )
-        .orderBy(
-          FirebaseQueryItems.createdAt.name,
-          descending: state.sortingType == SortingTypes.newest,
-        );
+    return buildApprovedQuery(
+      cityId: selectedCity.documentId,
+      categoryValues: state.categoryValues,
+      townCodes: state.townCodes,
+      sortingType: state.sortingType,
+    );
+  }
 
-    return query;
+  /// Builds the approved-places query for the given axes. Category and town are
+  /// server-side (`whereIn`); open-now/favorites are applied in memory by the
+  /// view because they have no Firestore field.
+  Query<StoreModel?> buildApprovedQuery({
+    required String cityId,
+    required Set<int> categoryValues,
+    required Set<int> townCodes,
+    required SortingTypes sortingType,
+  }) {
+    final reference = firebaseService.collectionReference(
+      CollectionPaths.approvedApplications,
+      StoreModel.empty(),
+    );
+
+    final filters = <Filter>[
+      Filter(FirebaseQueryItems.cityId.name, isEqualTo: cityId),
+      if (categoryValues.isNotEmpty)
+        Filter(_categoryValueField, whereIn: categoryValues.toList()),
+      if (townCodes.isNotEmpty)
+        Filter(_townCodeField, whereIn: townCodes.toList()),
+    ];
+
+    final combined = switch (filters.length) {
+      1 => filters[0],
+      2 => Filter.and(filters[0], filters[1]),
+      _ => Filter.and(filters[0], filters[1], filters[2]),
+    };
+
+    return reference.where(combined).orderBy(
+          sortingType.field,
+          descending: sortingType.descending,
+        );
   }
 
   void changeHomeViewCardType() {
@@ -56,9 +84,109 @@ final class HomeViewModel extends _$HomeViewModel with ProjectDependencyMixin {
   }
 
   Future<void> changeSortingType(SortingTypes type) async {
-    state = state.copyWith(sortingType: type, isLoading: true);
-    await Future.delayed(Durations.extralong4, () {
-      state = state.copyWith(isLoading: false);
-    });
+    if (state.sortingType == type) return;
+    state = state.copyWith(sortingType: type);
+    await _reloadPlaces();
   }
+
+  /// Quick single-category selection from the home chip bar.
+  /// [value] null clears the category filter ("Tümü").
+  Future<void> selectSingleCategory(int? value) async {
+    final next = value == null ? <int>{} : {value};
+    if (setEquals(state.categoryValues, next)) return;
+    state = state.copyWith(categoryValues: next);
+    await _reloadPlaces();
+  }
+
+  Future<void> applyFilters({
+    required Set<int> categoryValues,
+    required Set<int> townCodes,
+    required bool openNow,
+    required bool favoritesOnly,
+  }) async {
+    state = state.copyWith(
+      categoryValues: categoryValues,
+      townCodes: townCodes,
+      openNow: openNow,
+      favoritesOnly: favoritesOnly,
+    );
+    await _reloadPlaces();
+  }
+
+  Future<void> clearFilters() async {
+    if (!state.hasActiveFilters) return;
+    state = state.copyWith(
+      categoryValues: {},
+      townCodes: {},
+      openNow: false,
+      favoritesOnly: false,
+    );
+    await _reloadPlaces();
+  }
+
+  /// Live result count for the filter sheet CTA. Uses the cheap aggregate count
+  /// when there are no client-side axes; otherwise loads a bounded page and
+  /// filters in memory.
+  Future<int> countResults({
+    required Set<int> categoryValues,
+    required Set<int> townCodes,
+    required bool openNow,
+    required bool favoritesOnly,
+  }) async {
+    final selectedCity = ref.read(productProviderState).selectedCity;
+    final query = buildApprovedQuery(
+      cityId: selectedCity.documentId,
+      categoryValues: categoryValues,
+      townCodes: townCodes,
+      sortingType: state.sortingType,
+    );
+
+    if (!openNow && !favoritesOnly) {
+      final snapshot = await query.count().get();
+      return snapshot.count ?? 0;
+    }
+
+    final snapshot = await query.limit(_clientFilterLimit).get();
+    final models = snapshot.docs.map((e) => e.data()).whereType<StoreModel>();
+    return filterClientSide(
+      models,
+      openNow: openNow,
+      favoritesOnly: favoritesOnly,
+    ).length;
+  }
+
+  /// Applies open-now / favorites predicates in memory.
+  List<StoreModel> filterClientSide(
+    Iterable<StoreModel> models, {
+    required bool openNow,
+    required bool favoritesOnly,
+  }) {
+    final favoriteIds = favoritesOnly
+        ? ref
+            .read(productProviderState)
+            .favoritePlaces
+            .map((e) => e.documentId)
+            .toSet()
+        : const <String>{};
+
+    return models.where((model) {
+      if (openNow && StoreModelHelper(model: model).isStoreOpen != true) {
+        return false;
+      }
+      if (favoritesOnly && !favoriteIds.contains(model.documentId)) {
+        return false;
+      }
+      return true;
+    }).toList();
+  }
+
+  Future<void> _reloadPlaces() async {
+    state = state.copyWith(isLoading: true);
+    await Future<void>.delayed(Durations.long2);
+    state = state.copyWith(isLoading: false);
+  }
+
+  static const String _categoryValueField = 'category.value';
+  static const String _townCodeField = 'townCode';
+  static const int _clientFilterLimit = 300;
 }

--- a/lib/features/main/home/view/home_view.dart
+++ b/lib/features/main/home/view/home_view.dart
@@ -2,30 +2,34 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:kartal/kartal.dart' show ContextExtension, WidgetExtension;
+import 'package:kartal/kartal.dart' show WidgetExtension;
 import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/dependency/project_dependency_items.dart';
 import 'package:lifeclient/core/dependency/project_dependency_mixin.dart';
 import 'package:lifeclient/core/theme/app_colors.dart';
 import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/core/theme/app_shadows.dart';
 import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
 import 'package:lifeclient/features/main/home/provider/home_view_model.dart';
 import 'package:lifeclient/features/main/home/view/mixin/home_view_mixin.dart';
+import 'package:lifeclient/features/main/home/view/widget/place_filter_sheet.dart';
 import 'package:lifeclient/features/sub_feature/search/place_search_delegate.dart';
 import 'package:lifeclient/product/generated/assets.gen.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
-import 'package:lifeclient/product/model/enum/sorting_types.dart';
 import 'package:lifeclient/product/model/search_response_model.dart';
 import 'package:lifeclient/product/navigation/app_router.dart';
 import 'package:lifeclient/product/utility/constants/index.dart';
 import 'package:lifeclient/product/utility/decorations/empty_box.dart';
+import 'package:lifeclient/product/utility/extension/category_visual.dart';
 import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
 import 'package:lifeclient/product/utility/mixin/notification_type_mixin.dart';
-import 'package:lifeclient/product/widget/button/index.dart';
+import 'package:lifeclient/product/utility/mock/place_meta_mock.dart';
 import 'package:lifeclient/product/widget/card/general_place_card.dart';
 import 'package:lifeclient/product/widget/card/place/general_place_grid_card.dart';
 import 'package:lifeclient/product/widget/general/general_not_found_widget.dart';
 import 'package:lifeclient/product/widget/general/index.dart';
-import 'package:lifeclient/product/widget/sheet/general_select_sheet.dart';
+import 'package:lifeclient/product/widget/sheet/place_sort_sheet.dart';
 import 'package:lifeclient/sub_feature/advertisement_board/views/advertisement_slider.dart';
 
 part 'widget/home_categories_area.dart';
@@ -57,40 +61,9 @@ class _HomeViewState extends ConsumerState<HomeView>
         physics: const ClampingScrollPhysics(),
         slivers: [
           const AdvertisementSlider(),
-          SliverAppBar(
-            key: const Key('homeSliverAppBar'),
-            pinned: true,
-            flexibleSpace: FlexibleSpaceBar(
-              titlePadding: EdgeInsets.zero,
-              centerTitle: false,
-              background: Container(color: AppColors.surface),
-              title: Row(
-                children: [
-                  GeneralBigTitle(
-                    LocaleKeys.home_places.tr(),
-                    key: ValueKey('homePlacesTitle_${context.locale}'),
-                  ),
-                  const Spacer(),
-                  const _HomeSortGridView(),
-                ],
-              ),
-            ),
-          ),
-          SliverList.list(
-            children: [
-              IntrinsicHeight(
-                child: Row(
-                  spacing: AppSpacing.md,
-                  children: [
-                    const Expanded(child: _CustomSearchField()),
-                    _FilterButton(
-                      onTap: () => pushToFilter(context: context),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
+          const _HomeHeaderBlock(),
+          const _SearchFilterRow(),
+          const _ActiveFilterBar(),
           const _CategoriesItems(),
           const _HomePlaceArea(),
           const EmptyBox.largeXxHeight().ext.sliver,
@@ -103,21 +76,118 @@ class _HomeViewState extends ConsumerState<HomeView>
   bool get wantKeepAlive => true;
 }
 
+final class _HomeHeaderBlock extends ConsumerWidget {
+  const _HomeHeaderBlock();
+
+  static const _otherCategoryValue = 1000;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final city = ref
+        .watch(ProjectDependencyItems.productProviderState)
+        .selectedCity
+        .description;
+    final categoryValues = ref
+        .watch(homeViewModelProvider)
+        .categories
+        .where((e) => e.value != _otherCategoryValue)
+        .map((e) => e.value);
+    final total = CategoryCountMock.total(categoryValues);
+
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      sliver: SliverToBoxAdapter(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${city.toUpperCase()} · $total '
+                    '${LocaleKeys.home_placesUpper.tr()}',
+                    style: AppText.eyebrow,
+                  ),
+                  const SizedBox(height: AppSpacing.xxs),
+                  Text(
+                    LocaleKeys.home_places.tr(),
+                    key: ValueKey('homePlacesTitle_${context.locale}'),
+                    style: AppText.displayMd,
+                  ),
+                ],
+              ),
+            ),
+            const _HomeSortGridView(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+final class _SearchFilterRow extends StatelessWidget {
+  const _SearchFilterRow();
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            spacing: AppSpacing.md,
+            children: [
+              const Expanded(child: _CustomSearchField()),
+              _FilterButton(
+                onTap: () => PlaceFilterSheet.show(context),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 final class _FilterButton extends StatelessWidget {
   const _FilterButton({required this.onTap});
   final VoidCallback onTap;
+
   @override
   Widget build(BuildContext context) {
-    return ElevatedButton(
-      key: const Key('homeFilterButton'),
-      onPressed: onTap,
-      style: ElevatedButton.styleFrom(
-        backgroundColor: AppColors.surface,
-        shape: RoundedRectangleBorder(borderRadius: .circular(AppRadius.md)),
-      ),
-      child: Icon(
-        AppIcons.filter,
-        color: context.general.colorScheme.onSecondaryFixed,
+    return SizedBox(
+      width: 48,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: Material(
+              color: AppColors.ink50,
+              borderRadius: BorderRadius.circular(AppRadius.md),
+              clipBehavior: Clip.antiAlias,
+              child: InkWell(
+                key: const Key('homeFilterButton'),
+                onTap: onTap,
+                child: const Center(
+                  child: Icon(AppIcons.filter, color: AppColors.ink500),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            top: AppSpacing.xs,
+            right: AppSpacing.xs,
+            child: Container(
+              width: AppSpacing.xs,
+              height: AppSpacing.xs,
+              decoration: const BoxDecoration(
+                color: AppColors.coral,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -130,6 +200,7 @@ final class _CustomSearchField extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextField(
       key: const Key('homeSearchField'),
+      readOnly: true,
       onTap: () async {
         await showSearch<SearchResponse>(
           context: context,
@@ -137,14 +208,22 @@ final class _CustomSearchField extends StatelessWidget {
         );
       },
       decoration: InputDecoration(
+        filled: true,
+        fillColor: AppColors.ink50,
         hintText: LocaleKeys.search_place.tr(),
-        prefixIcon: Icon(
-          AppIcons.search,
-          color: context.general.colorScheme.onSecondaryFixed,
-        ),
+        hintStyle: AppText.body.copyWith(color: AppColors.ink400),
+        prefixIcon: const Icon(AppIcons.search, color: AppColors.ink400),
+        border: _searchBorder,
+        enabledBorder: _searchBorder,
+        focusedBorder: _searchBorder,
       ),
     );
   }
+
+  OutlineInputBorder get _searchBorder => OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadius.md),
+        borderSide: BorderSide.none,
+      );
 }
 
 final class _CategoriesItems extends ConsumerWidget {
@@ -163,6 +242,88 @@ final class _CategoriesItems extends ConsumerWidget {
       key: ValueKey('homeCategoriesSection'),
       padding: PagePadding.vertical6Symmetric(),
       sliver: _HomeCategoryCards(),
+    );
+  }
+}
+
+final class _ActiveFilterBar extends ConsumerWidget {
+  const _ActiveFilterBar();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(homeViewModelProvider);
+    if (!state.hasActiveFilters) {
+      return const SliverToBoxAdapter(child: SizedBox.shrink());
+    }
+
+    final parts = <String>[
+      if (state.categoryValues.isNotEmpty)
+        LocaleKeys.filter_categoryCountLabel.tr(
+          args: ['${state.categoryValues.length}'],
+        ),
+      if (state.townCodes.isNotEmpty)
+        LocaleKeys.filter_districtCountLabel.tr(
+          args: ['${state.townCodes.length}'],
+        ),
+      if (state.openNow) LocaleKeys.filter_openShort.tr(),
+      if (state.favoritesOnly) LocaleKeys.filter_favoritesShort.tr(),
+    ];
+
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+        child: Row(
+          children: [
+            Expanded(
+              child: Material(
+                color: AppColors.coral50,
+                borderRadius: BorderRadius.circular(AppRadius.pill),
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(AppRadius.pill),
+                  onTap: () => PlaceFilterSheet.show(context),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm,
+                      vertical: AppSpacing.xs,
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          AppIcons.filter,
+                          size: 16,
+                          color: AppColors.coral,
+                        ),
+                        const SizedBox(width: AppSpacing.xs),
+                        Expanded(
+                          child: Text(
+                            parts.join(' · '),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: AppText.caption.copyWith(
+                              color: AppColors.coral700,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+            InkWell(
+              onTap: () =>
+                  ref.read(homeViewModelProvider.notifier).clearFilters(),
+              borderRadius: BorderRadius.circular(AppRadius.pill),
+              child: const Padding(
+                padding: EdgeInsets.all(AppSpacing.xs),
+                child: Icon(AppIcons.close, size: 18, color: AppColors.ink500),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/main/home/view/widget/home_categories_area.dart
+++ b/lib/features/main/home/view/widget/home_categories_area.dart
@@ -10,17 +10,20 @@ mixin _FilterMixin {
   }
 }
 
-final class _HomeCategoryCards extends ConsumerWidget with _FilterMixin {
+final class _HomeCategoryCards extends ConsumerWidget {
   const _HomeCategoryCards();
   static const _maxCategoryItemLength = 6;
   static const _otherCategoryValue = 1000;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final categories = ref.watch(homeViewModelProvider).categories
-      ..take(_maxCategoryItemLength)
-      ..sort((a, b) => a.displayName.length.compareTo(b.displayName.length))
-      /// remove other category
-      ..removeWhere((element) => element.value == _otherCategoryValue);
+    final vm = ref.watch(homeViewModelProvider);
+    final selected = vm.categoryValues;
+    final categories =
+        vm.categories.where((e) => e.value != _otherCategoryValue).toList()
+          ..sort((a, b) => a.displayName.length.compareTo(b.displayName.length));
+    final visible = categories.take(_maxCategoryItemLength).toList();
+    final total = CategoryCountMock.total(visible.map((e) => e.value));
 
     return SingleChildScrollView(
       key: const Key('homeCategoriesList'),
@@ -28,16 +31,28 @@ final class _HomeCategoryCards extends ConsumerWidget with _FilterMixin {
       child: Row(
         spacing: AppSpacing.xs,
         children: [
-          for (final category in categories)
+          _CategoryCard(
+            key: const Key('categoryCard_all'),
+            name: LocaleKeys.home_allCategory.tr(),
+            count: total,
+            icon: CategoryVisual.allIcon,
+            accent: AppColors.coral,
+            isActive: selected.isEmpty,
+            onTap: () => ref
+                .read(homeViewModelProvider.notifier)
+                .selectSingleCategory(null),
+          ),
+          for (final category in visible)
             _CategoryCard(
-              key: Key('categoryCard_${category.documentId}'),
-              onTap: () async {
-                await pushToFilter(
-                  context: context,
-                  category: category.documentId,
-                );
-              },
+              key: Key('categoryCard_${category.value}'),
               name: category.displayName,
+              count: CategoryCountMock.forValue(category.value),
+              icon: CategoryVisual.iconFor(category),
+              accent: CategoryVisual.accentFor(category),
+              isActive: selected.contains(category.value),
+              onTap: () => ref
+                  .read(homeViewModelProvider.notifier)
+                  .selectSingleCategory(category.value),
             ),
         ],
       ),
@@ -46,26 +61,106 @@ final class _HomeCategoryCards extends ConsumerWidget with _FilterMixin {
 }
 
 final class _CategoryCard extends StatelessWidget {
-  const _CategoryCard({required this.name, required this.onTap, super.key});
+  const _CategoryCard({
+    required this.name,
+    required this.count,
+    required this.icon,
+    required this.accent,
+    required this.isActive,
+    required this.onTap,
+    super.key,
+  });
 
   final String name;
+  final int count;
+  final IconData icon;
+  final Color accent;
+  final bool isActive;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return ElevatedButton(
-      onPressed: onTap,
-      style: ElevatedButton.styleFrom(
-        side: const BorderSide(color: AppColors.surface),
-        backgroundColor: AppColors.surface,
-        shape: RoundedRectangleBorder(borderRadius: .circular(AppRadius.md)),
-      ),
-      child: Text(
-        name,
-        style: context.general.textTheme.bodySmall?.copyWith(
-          fontWeight: FontWeight.w600,
-          color: context.general.colorScheme.onSecondaryFixed,
+    final foreground = isActive ? AppColors.white : AppColors.ink700;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: isActive ? AppColors.coral : AppColors.surface,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+        border: Border.all(
+          color: isActive ? AppColors.coral : AppColors.ink100,
+          width: isActive ? 1.5 : 1,
         ),
+        boxShadow: isActive ? AppShadows.card : null,
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppRadius.pill),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.xs,
+              vertical: 6,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _CategoryIconBadge(
+                  icon: icon,
+                  isActive: isActive,
+                  accent: accent,
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Text(
+                  name,
+                  style: AppText.body.copyWith(
+                    color: foreground,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xxs),
+                Text(
+                  '$count',
+                  style: AppText.caption.copyWith(
+                    color: isActive ? AppColors.white : AppColors.ink400,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _CategoryIconBadge extends StatelessWidget {
+  const _CategoryIconBadge({
+    required this.icon,
+    required this.isActive,
+    required this.accent,
+  });
+
+  final IconData icon;
+  final bool isActive;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 22,
+      height: 22,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: isActive
+            ? AppColors.white.withValues(alpha: 0.22)
+            : AppColors.ink25,
+        shape: BoxShape.circle,
+      ),
+      child: Icon(
+        icon,
+        size: 13,
+        color: isActive ? AppColors.white : accent,
       ),
     );
   }

--- a/lib/features/main/home/view/widget/home_place_area.dart
+++ b/lib/features/main/home/view/widget/home_place_area.dart
@@ -11,52 +11,131 @@ class __HomePlaceAreaState extends ConsumerState<_HomePlaceArea>
     with ProjectDependencyMixin, _HomePlaceAreaMixin {
   @override
   Widget build(BuildContext context) {
-    final isLoading = ref.watch(homeViewModelProvider).isLoading;
-    if (isLoading) {
+    final vm = ref.watch(homeViewModelProvider);
+    if (vm.isLoading) {
       return SliverToBoxAdapter(child: Assets.lottie.loadingGray.lottie());
     }
+    if (vm.hasClientFilters) {
+      return _ClientFilteredPlaceArea(
+        query: query,
+        isGridDesign: vm.isGridView,
+        openNow: vm.openNow,
+        favoritesOnly: vm.favoritesOnly,
+      );
+    }
     return FirestoreSliverListView(
-      emptyBuilder:
-          (context) => GeneralNotFoundWidget(
-            title: LocaleKeys.notification_placeNotFoundErrorMessage.tr(),
-            onRefresh: () async {
-              await query.get();
-            },
-          ),
+      emptyBuilder: _placeEmptyWidget,
       query: query,
-      isGridDesign: ref.watch(homeViewModelProvider).isGridView,
-      itemGridBuilder: (context, model) {
-        return Semantics(
-          identifier: 'place_grid_card_${model.name}',
-          child: Padding(
-            padding: const PagePadding.onlyBottom(),
-            child: GeneralPlaceGridCard(
-              onCardTap: () {
-                PlaceDetailRoute(
-                  $extra: model,
-                  id: model.documentId,
-                ).push<PlaceDetailRoute>(context);
-              },
-              storeModel: model,
-            ),
-          ),
-        );
-      },
-      itemBuilder: (context, model) {
-        return Padding(
-          padding: const PagePadding.onlyBottom(),
-          child: GeneralPlaceCard(
-            onCardTap: () {
-              PlaceDetailRoute(
-                $extra: model,
-                id: model.documentId,
-              ).push<PlaceDetailRoute>(context);
-            },
-            storeModel: model,
-          ),
-        );
-      },
+      isGridDesign: vm.isGridView,
+      itemGridBuilder: _gridItem,
+      itemBuilder: _listItem,
       onRetry: () {},
+    );
+  }
+
+  Widget _placeEmptyWidget(BuildContext context) {
+    return GeneralNotFoundWidget(
+      title: LocaleKeys.notification_placeNotFoundErrorMessage.tr(),
+      onRefresh: () async {
+        await query.get();
+      },
+    );
+  }
+}
+
+Widget _gridItem(BuildContext context, StoreModel model) {
+  return Semantics(
+    identifier: 'place_grid_card_${model.name}',
+    child: Padding(
+      padding: const PagePadding.onlyBottom(),
+      child: GeneralPlaceGridCard(
+        onCardTap: () => _openDetail(context, model),
+        storeModel: model,
+      ),
+    ),
+  );
+}
+
+Widget _listItem(BuildContext context, StoreModel model) {
+  return Padding(
+    padding: const PagePadding.onlyBottom(),
+    child: GeneralPlaceCard(
+      onCardTap: () => _openDetail(context, model),
+      storeModel: model,
+    ),
+  );
+}
+
+void _openDetail(BuildContext context, StoreModel model) {
+  PlaceDetailRoute(
+    $extra: model,
+    id: model.documentId,
+  ).push<PlaceDetailRoute>(context);
+}
+
+/// In-memory filtered list for the open-now / favorites axes, which have no
+/// Firestore field. Loads a bounded page and filters via the view model.
+final class _ClientFilteredPlaceArea extends ConsumerWidget {
+  const _ClientFilteredPlaceArea({
+    required this.query,
+    required this.isGridDesign,
+    required this.openNow,
+    required this.favoritesOnly,
+  });
+
+  static const int _limit = 300;
+
+  final Query<StoreModel?> query;
+  final bool isGridDesign;
+  final bool openNow;
+  final bool favoritesOnly;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return StreamBuilder<QuerySnapshot<StoreModel?>>(
+      stream: query.limit(_limit).snapshots(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return SliverToBoxAdapter(child: Assets.lottie.loadingGray.lottie());
+        }
+        final models = snapshot.data!.docs
+            .map((e) => e.data())
+            .whereType<StoreModel>();
+        final places = ref
+            .read(homeViewModelProvider.notifier)
+            .filterClientSide(
+              models,
+              openNow: openNow,
+              favoritesOnly: favoritesOnly,
+            );
+
+        if (places.isEmpty) {
+          return SliverToBoxAdapter(
+            child: GeneralNotFoundWidget(
+              title: LocaleKeys.notification_placeNotFoundErrorMessage.tr(),
+              onRefresh: () async {},
+            ),
+          );
+        }
+
+        if (isGridDesign) {
+          return SliverGrid.builder(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: AppSpacing.md,
+              mainAxisSpacing: AppSpacing.sm,
+              mainAxisExtent: MediaQuery.sizeOf(context).height * 0.24,
+            ),
+            itemCount: places.length,
+            itemBuilder: (context, index) => _gridItem(context, places[index]),
+          );
+        }
+
+        return SliverList.builder(
+          itemCount: places.length,
+          itemBuilder: (context, index) => _listItem(context, places[index]),
+        );
+      },
     );
   }
 }

--- a/lib/features/main/home/view/widget/home_sort_grid_view.dart
+++ b/lib/features/main/home/view/widget/home_sort_grid_view.dart
@@ -7,7 +7,36 @@ final class _HomeSortGridView extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Row(
       key: Key('homeSortGridView'),
+      spacing: AppSpacing.xs,
       children: [_ViewDesignButton(), _SortPlaceButton()],
+    );
+  }
+}
+
+final class _BoxedButton extends StatelessWidget {
+  const _BoxedButton({required this.onTap, required this.child});
+
+  final VoidCallback onTap;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 38,
+      height: 38,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+        border: Border.all(color: AppColors.ink100),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          child: Center(child: child),
+        ),
+      ),
     );
   }
 }
@@ -17,12 +46,16 @@ final class _ViewDesignButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return AnimatedButton(
-      isAnimated: ref.watch(homeViewModelProvider).isGridView,
-      onPressed: () async {
+    final isGridView = ref.watch(homeViewModelProvider).isGridView;
+    return _BoxedButton(
+      onTap: () async {
         ref.read(homeViewModelProvider.notifier).changeHomeViewCardType();
       },
-      icon: AnimatedIcons.list_view,
+      child: Icon(
+        isGridView ? Icons.view_list_rounded : Icons.grid_view_rounded,
+        size: 20,
+        color: AppColors.navy,
+      ),
     );
   }
 }
@@ -32,33 +65,28 @@ final class _SortPlaceButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return IconButton(
-      onPressed: () async {
+    return _BoxedButton(
+      onTap: () async {
         final currentType = ref.read(homeViewModelProvider).sortingType;
-        final result = await GeneralSelectSheet.show(
-          context,
-          isDismissible: true,
-          mainAxisSize: MainAxisSize.min,
-          items: [
-            SelectSheetModel(
-              title: SortingTypes.newest.detail.tr(),
-              id: SortingTypes.newest.name,
-            ),
-            SelectSheetModel(
-              title: SortingTypes.oldest.detail.tr(),
-              id: SortingTypes.oldest.name,
-            ),
-          ],
-          initialItem: SelectSheetModel(title: '', id: currentType.name),
-        );
+        final result = await PlaceSortSheet.show(context, current: currentType);
         if (result == null) return;
         await ref
             .read(homeViewModelProvider.notifier)
-            .changeSortingType(SortingTypes.values.byName(result.id));
+            .changeSortingType(result);
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context)
+          ..clearSnackBars()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(LocaleKeys.sorting_applied.tr()),
+              behavior: SnackBarBehavior.floating,
+              duration: Durations.extralong4,
+            ),
+          );
       },
-      icon: Icon(
-        Icons.sort_by_alpha_outlined,
-        color: context.general.colorScheme.onSecondaryFixed,
+      child: Text(
+        'A↑Z',
+        style: AppText.label.copyWith(color: AppColors.navy),
       ),
     );
   }

--- a/lib/features/main/home/view/widget/place_filter_sheet.dart
+++ b/lib/features/main/home/view/widget/place_filter_sheet.dart
@@ -1,0 +1,661 @@
+import 'dart:async';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
+import 'package:lifeclient/features/main/home/provider/home_view_model.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+import 'package:lifeclient/product/utility/constants/app_icons.dart';
+import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
+
+/// Full-height "Filtre" sheet with a draft state that is only committed to the
+/// home list when the CTA is pressed. Category + district filter server-side;
+/// open-now + favorites filter in memory (see [HomeViewModel]).
+final class PlaceFilterSheet extends ConsumerStatefulWidget {
+  const PlaceFilterSheet({super.key});
+
+  static const int _otherCategoryValue = 1000;
+
+  static Future<void> show(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.surface,
+      shape: RoundedRectangleBorder(borderRadius: AppRadius.sheet),
+      builder: (_) => const PlaceFilterSheet(),
+    );
+  }
+
+  @override
+  ConsumerState<PlaceFilterSheet> createState() => _PlaceFilterSheetState();
+}
+
+class _PlaceFilterSheetState extends ConsumerState<PlaceFilterSheet>
+    with AppProviderMixin<PlaceFilterSheet> {
+  late Set<int> _categoryValues;
+  late Set<int> _townCodes;
+  late bool _openNow;
+  late bool _favoritesOnly;
+
+  final _searchController = TextEditingController();
+  String _townQuery = '';
+  Timer? _debounce;
+  int _countToken = 0;
+  int? _resultCount;
+  bool _countLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final state = ref.read(homeViewModelProvider);
+    _categoryValues = {...state.categoryValues};
+    _townCodes = {...state.townCodes};
+    _openNow = state.openNow;
+    _favoritesOnly = state.favoritesOnly;
+    _searchController.addListener(() {
+      setState(() => _townQuery = _searchController.text.trim().toLowerCase());
+    });
+    unawaited(_recount());
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onDraftChanged() {
+    setState(() {});
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), _recount);
+  }
+
+  Future<void> _recount() async {
+    final token = ++_countToken;
+    setState(() => _countLoading = true);
+    final count = await ref.read(homeViewModelProvider.notifier).countResults(
+          categoryValues: _categoryValues,
+          townCodes: _townCodes,
+          openNow: _openNow,
+          favoritesOnly: _favoritesOnly,
+        );
+    if (!mounted || token != _countToken) return;
+    setState(() {
+      _resultCount = count;
+      _countLoading = false;
+    });
+  }
+
+  void _toggleCategory(int value) {
+    if (!_categoryValues.remove(value)) _categoryValues.add(value);
+    _onDraftChanged();
+  }
+
+  void _toggleTown(int code) {
+    if (!_townCodes.remove(code)) _townCodes.add(code);
+    _onDraftChanged();
+  }
+
+  void _clearAll() {
+    _categoryValues = {};
+    _townCodes = {};
+    _openNow = false;
+    _favoritesOnly = false;
+    _searchController.clear();
+    _onDraftChanged();
+  }
+
+  void _apply() {
+    unawaited(
+      ref.read(homeViewModelProvider.notifier).applyFilters(
+            categoryValues: _categoryValues,
+            townCodes: _townCodes,
+            openNow: _openNow,
+            favoritesOnly: _favoritesOnly,
+          ),
+    );
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final categories = productState.categoryItems
+        .where((e) => e.value != PlaceFilterSheet._otherCategoryValue)
+        .toList();
+    final towns = productProvider.regionalTowns;
+    final filteredTowns = _townQuery.isEmpty
+        ? towns
+        : towns
+            .where((t) => t.displayName.toLowerCase().contains(_townQuery))
+            .toList();
+
+    return SizedBox(
+      height: MediaQuery.sizeOf(context).height * 0.92,
+      child: SafeArea(
+        bottom: false,
+        child: Column(
+          children: [
+            const _SheetHandle(),
+            _Header(onClear: _clearAll),
+            const Divider(height: 1, color: AppColors.ink50),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.lg,
+                  AppSpacing.lg,
+                  AppSpacing.lg,
+                  AppSpacing.xl,
+                ),
+                children: [
+                  _SectionHeader(
+                    title: LocaleKeys.filter_categories.tr(),
+                    trailing: _countLabel(_categoryValues.length, categories.length),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  Wrap(
+                    spacing: AppSpacing.xs,
+                    runSpacing: AppSpacing.xs,
+                    children: [
+                      for (final category in categories)
+                        _FilterChip(
+                          label: category.displayName.toUpperCase(),
+                          isSelected: _categoryValues.contains(category.value),
+                          onTap: () => _toggleCategory(category.value),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: AppSpacing.xl),
+                  _SectionTitle(LocaleKeys.filter_others.tr()),
+                  const SizedBox(height: AppSpacing.xs),
+                  _ToggleRow(
+                    icon: Icons.schedule_outlined,
+                    label: LocaleKeys.filter_openNow.tr(),
+                    value: _openNow,
+                    onChanged: (value) {
+                      _openNow = value;
+                      _onDraftChanged();
+                    },
+                  ),
+                  _ToggleRow(
+                    icon: AppIcons.favoriteBorder,
+                    label: LocaleKeys.filter_favoritesOnly.tr(),
+                    value: _favoritesOnly,
+                    onChanged: (value) {
+                      _favoritesOnly = value;
+                      _onDraftChanged();
+                    },
+                  ),
+                  const SizedBox(height: AppSpacing.xl),
+                  _SectionHeader(
+                    title: LocaleKeys.filter_districts.tr(),
+                    trailing: _countLabel(_townCodes.length, towns.length),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  _TownSearchField(controller: _searchController),
+                  const SizedBox(height: AppSpacing.sm),
+                  _NearYouChips(
+                    towns: towns.take(3).toList(),
+                    selected: _townCodes,
+                    onTap: _toggleTown,
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  for (final town in filteredTowns)
+                    _TownCheckRow(
+                      name: town.displayName,
+                      isSelected: _townCodes.contains(town.code),
+                      onTap: () => _toggleTown(town.code),
+                    ),
+                ],
+              ),
+            ),
+            _CtaFooter(
+              count: _resultCount,
+              loading: _countLoading,
+              onApply: _apply,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _countLabel(int selected, int total) =>
+      LocaleKeys.filter_selectedCount.tr(args: ['$selected', '$total']);
+}
+
+final class _SheetHandle extends StatelessWidget {
+  const _SheetHandle();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 36,
+      height: 4,
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+      decoration: BoxDecoration(
+        color: AppColors.ink200,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+      ),
+    );
+  }
+}
+
+final class _Header extends StatelessWidget {
+  const _Header({required this.onClear});
+
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+      child: Row(
+        children: [
+          Expanded(
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton(
+                onPressed: onClear,
+                child: Text(
+                  LocaleKeys.filter_clear.tr(),
+                  style: AppText.label.copyWith(color: AppColors.ink500),
+                ),
+              ),
+            ),
+          ),
+          Text(
+            LocaleKeys.filter_title.tr(),
+            style: AppText.title.copyWith(fontSize: 18),
+          ),
+          Expanded(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: IconButton(
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(AppIcons.close, color: AppColors.ink500),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+final class _SectionTitle extends StatelessWidget {
+  const _SectionTitle(this.title);
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(title, style: AppText.title);
+  }
+}
+
+final class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title, required this.trailing});
+
+  final String title;
+  final String trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        _SectionTitle(title),
+        Text(
+          trailing,
+          style: AppText.label.copyWith(color: AppColors.coral),
+        ),
+      ],
+    );
+  }
+}
+
+final class _FilterChip extends StatelessWidget {
+  const _FilterChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: isSelected ? AppColors.coral50 : AppColors.surface,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+        border: Border.all(
+          color: isSelected ? AppColors.coral : AppColors.ink100,
+          width: isSelected ? 1.5 : 1,
+        ),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppRadius.pill),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+              vertical: AppSpacing.xs,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  isSelected ? AppIcons.check : AppIcons.add,
+                  size: 16,
+                  color: isSelected ? AppColors.coral : AppColors.ink400,
+                ),
+                const SizedBox(width: AppSpacing.xxs),
+                Text(
+                  label,
+                  style: AppText.caption.copyWith(
+                    color: isSelected ? AppColors.coral700 : AppColors.ink700,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _ToggleRow extends StatelessWidget {
+  const _ToggleRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xxs),
+      child: Row(
+        children: [
+          Icon(icon, color: AppColors.ink500),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Text(
+              label,
+              style: AppText.body.copyWith(
+                color: AppColors.ink900,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Switch(
+            value: value,
+            onChanged: onChanged,
+            activeTrackColor: AppColors.coral,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+final class _TownSearchField extends StatelessWidget {
+  const _TownSearchField({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        filled: true,
+        fillColor: AppColors.ink50,
+        hintText: LocaleKeys.filter_searchDistrict.tr(),
+        hintStyle: AppText.body.copyWith(color: AppColors.ink400),
+        prefixIcon: const Icon(AppIcons.search, color: AppColors.ink400),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          borderSide: BorderSide.none,
+        ),
+      ),
+    );
+  }
+}
+
+final class _NearYouChips extends StatelessWidget {
+  const _NearYouChips({
+    required this.towns,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final List<RegionalTownSubItem> towns;
+  final Set<int> selected;
+  final void Function(int code) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (towns.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Icon(Icons.near_me_outlined, size: 16, color: AppColors.teal),
+            const SizedBox(width: AppSpacing.xxs),
+            Text(
+              LocaleKeys.filter_nearYou.tr(),
+              style: AppText.caption.copyWith(
+                color: AppColors.teal600,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Wrap(
+          spacing: AppSpacing.xs,
+          runSpacing: AppSpacing.xs,
+          children: [
+            for (final town in towns)
+              _NearYouChip(
+                label: town.displayName,
+                isSelected: selected.contains(town.code),
+                onTap: () => onTap(town.code),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+final class _NearYouChip extends StatelessWidget {
+  const _NearYouChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: isSelected ? AppColors.teal : AppColors.teal50,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+        border: Border.all(color: AppColors.teal200),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(AppRadius.pill),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+              vertical: AppSpacing.xs,
+            ),
+            child: Text(
+              label,
+              style: AppText.caption.copyWith(
+                color: isSelected ? AppColors.white : AppColors.teal700,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _TownCheckRow extends StatelessWidget {
+  const _TownCheckRow({
+    required this.name,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String name;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+        child: Row(
+          children: [
+            Container(
+              width: 22,
+              height: 22,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: isSelected ? AppColors.navy : AppColors.surface,
+                borderRadius: BorderRadius.circular(AppRadius.sm),
+                border: Border.all(
+                  color: isSelected ? AppColors.navy : AppColors.ink200,
+                ),
+              ),
+              child: isSelected
+                  ? const Icon(AppIcons.check, size: 15, color: AppColors.white)
+                  : null,
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Text(
+                name,
+                style: AppText.body.copyWith(color: AppColors.ink900),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+final class _CtaFooter extends StatelessWidget {
+  const _CtaFooter({
+    required this.count,
+    required this.loading,
+    required this.onApply,
+  });
+
+  final int? count;
+  final bool loading;
+  final VoidCallback onApply;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolved = count ?? 0;
+    final enabled = !loading && resolved > 0;
+    final label = resolved == 0 && !loading
+        ? LocaleKeys.filter_noResults.tr()
+        : LocaleKeys.filter_showResults.tr(args: ['$resolved']);
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.sm,
+        AppSpacing.lg,
+        AppSpacing.sm,
+      ),
+      decoration: const BoxDecoration(
+        color: AppColors.surface,
+        border: Border(top: BorderSide(color: AppColors.ink50)),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Opacity(
+          opacity: enabled ? 1 : 0.4,
+          child: Material(
+            color: AppColors.navy,
+            borderRadius: BorderRadius.circular(AppRadius.md),
+            child: InkWell(
+              borderRadius: BorderRadius.circular(AppRadius.md),
+              onTap: enabled ? onApply : null,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (loading)
+                      const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: AppColors.white,
+                        ),
+                      )
+                    else ...[
+                      Text(
+                        label,
+                        style: AppText.label.copyWith(color: AppColors.white),
+                      ),
+                      if (enabled) ...[
+                        const SizedBox(width: AppSpacing.xs),
+                        const Icon(
+                          Icons.arrow_forward_rounded,
+                          size: 18,
+                          color: AppColors.white,
+                        ),
+                      ],
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/product/init/language/locale_keys.g.dart
+++ b/lib/product/init/language/locale_keys.g.dart
@@ -105,6 +105,8 @@ abstract class  LocaleKeys {
   static const home_places = 'home.places';
   static const home_search = 'home.search';
   static const home_notifications = 'home.notifications';
+  static const home_allCategory = 'home.allCategory';
+  static const home_placesUpper = 'home.placesUpper';
   static const home = 'home';
   static const message_emptySearch = 'message.emptySearch';
   static const message_somethingWentWrong = 'message.somethingWentWrong';
@@ -268,12 +270,20 @@ abstract class  LocaleKeys {
   static const sorting_time_newest = 'sorting.time.newest';
   static const sorting_time_oldest = 'sorting.time.oldest';
   static const sorting_time = 'sorting.time';
+  static const sorting_title = 'sorting.title';
+  static const sorting_applied = 'sorting.applied';
+  static const sorting_alpha_aToZ = 'sorting.alpha.aToZ';
+  static const sorting_alpha_zToA = 'sorting.alpha.zToA';
+  static const sorting_alpha = 'sorting.alpha';
   static const sorting = 'sorting';
   static const utils_options = 'utils.options';
   static const utils = 'utils';
   static const advertisementBoard_openUrl = 'advertisementBoard.openUrl';
   static const advertisementBoard_launchUrlError = 'advertisementBoard.launchUrlError';
   static const advertisementBoard_shareAdvertisementSubject = 'advertisementBoard.shareAdvertisementSubject';
+  static const advertisementBoard_houseAdTitle = 'advertisementBoard.houseAdTitle';
+  static const advertisementBoard_houseAdSubtitle = 'advertisementBoard.houseAdSubtitle';
+  static const advertisementBoard_contactUs = 'advertisementBoard.contactUs';
   static const advertisementBoard = 'advertisementBoard';
   static const chain_stores_title = 'chain_stores.title';
   static const chain_stores_showAllSubBranches = 'chain_stores.showAllSubBranches';
@@ -328,5 +338,22 @@ abstract class  LocaleKeys {
   static const historyPage_favorites = 'historyPage.favorites';
   static const historyPage_shareSubject = 'historyPage.shareSubject';
   static const historyPage = 'historyPage';
+  static const filter_title = 'filter.title';
+  static const filter_clear = 'filter.clear';
+  static const filter_categories = 'filter.categories';
+  static const filter_others = 'filter.others';
+  static const filter_openNow = 'filter.openNow';
+  static const filter_favoritesOnly = 'filter.favoritesOnly';
+  static const filter_districts = 'filter.districts';
+  static const filter_nearYou = 'filter.nearYou';
+  static const filter_searchDistrict = 'filter.searchDistrict';
+  static const filter_selectedCount = 'filter.selectedCount';
+  static const filter_showResults = 'filter.showResults';
+  static const filter_noResults = 'filter.noResults';
+  static const filter_categoryCountLabel = 'filter.categoryCountLabel';
+  static const filter_districtCountLabel = 'filter.districtCountLabel';
+  static const filter_openShort = 'filter.openShort';
+  static const filter_favoritesShort = 'filter.favoritesShort';
+  static const filter = 'filter';
 
 }

--- a/lib/product/model/enum/sorting_types.dart
+++ b/lib/product/model/enum/sorting_types.dart
@@ -1,13 +1,47 @@
+import 'package:flutter/material.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 
 enum SortingTypes {
-  newest(LocaleKeys.sorting_time_newest),
-  oldest(LocaleKeys.sorting_time_oldest);
+  newest(
+    detail: LocaleKeys.sorting_time_newest,
+    icon: Icons.arrow_downward_rounded,
+    field: 'createdAt',
+    descending: true,
+  ),
+  oldest(
+    detail: LocaleKeys.sorting_time_oldest,
+    icon: Icons.arrow_upward_rounded,
+    field: 'createdAt',
+    descending: false,
+  ),
+  aToZ(
+    detail: LocaleKeys.sorting_alpha_aToZ,
+    icon: Icons.sort_by_alpha_rounded,
+    field: 'name',
+    descending: false,
+  ),
+  zToA(
+    detail: LocaleKeys.sorting_alpha_zToA,
+    icon: Icons.sort_by_alpha_rounded,
+    field: 'name',
+    descending: true,
+  );
+
+  const SortingTypes({
+    required this.detail,
+    required this.icon,
+    required this.field,
+    required this.descending,
+  });
 
   final String detail;
-  // ignore: sort_constructors_first
-  // This constructor order is intentional for better readability
-  const SortingTypes(this.detail);
+  final IconData icon;
+
+  /// Firestore field this sort orders by.
+  final String field;
+
+  /// Order direction for [field].
+  final bool descending;
 
   SortingTypes change() {
     return this == SortingTypes.newest

--- a/lib/product/utility/carousel/custom_carousel_options.dart
+++ b/lib/product/utility/carousel/custom_carousel_options.dart
@@ -12,6 +12,7 @@ final class CustomCarouselOptions extends CarouselOptions {
   /// * autoPlay: true
   CustomCarouselOptions.advertisement({
     double height = 150,
+    super.onPageChanged,
   }) : super(
           autoPlayAnimationDuration: DurationConstant.durationNormal,
           height: height,

--- a/lib/product/utility/extension/category_visual.dart
+++ b/lib/product/utility/extension/category_visual.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_colors.dart';
+
+/// Resolves a stable icon + accent color for a [CategoryModel] so category
+/// chips and image-less place cards render with varied, brand-aligned visuals.
+///
+/// The taxonomy has no icon/color field, so we derive both from
+/// [CategoryModel.value]. Swap [iconFor]/[accentFor] with a real mapping if the
+/// backend later ships per-category assets.
+final class CategoryVisual {
+  const CategoryVisual._();
+
+  static const IconData allIcon = Icons.grid_view_rounded;
+
+  static const _icons = <IconData>[
+    Icons.storefront_outlined,
+    Icons.restaurant_outlined,
+    Icons.local_cafe_outlined,
+    Icons.hotel_outlined,
+    Icons.fitness_center_outlined,
+    Icons.school_outlined,
+    Icons.local_hospital_outlined,
+    Icons.shopping_bag_outlined,
+    Icons.pets_outlined,
+    Icons.spa_outlined,
+  ];
+
+  static const _accents = <Color>[
+    AppColors.coral,
+    AppColors.teal,
+    AppColors.olive,
+    AppColors.navy400,
+    AppColors.gold300,
+  ];
+
+  static IconData iconFor(CategoryModel? category) {
+    if (category == null) return allIcon;
+    return _icons[category.value.abs() % _icons.length];
+  }
+
+  static Color accentFor(CategoryModel? category) {
+    if (category == null) return AppColors.navy;
+    return _accents[category.value.abs() % _accents.length];
+  }
+}

--- a/lib/product/utility/mock/place_meta_mock.dart
+++ b/lib/product/utility/mock/place_meta_mock.dart
@@ -1,0 +1,46 @@
+import 'package:life_shared/life_shared.dart';
+
+/// Deterministic placeholder meta (rating, review count, distance) for a
+/// [StoreModel] until the backend exposes real values.
+///
+/// Numbers are derived from [StoreModel.documentId] so a given place always
+/// renders the same values. Replace the getters with real model fields once the
+/// data is available — this is the single seam for that swap.
+final class PlaceMetaMock {
+  const PlaceMetaMock(this.store);
+
+  final StoreModel store;
+
+  int get _seed {
+    final source = store.documentId.isNotEmpty ? store.documentId : store.name;
+    var hash = 0;
+    for (final unit in source.codeUnits) {
+      hash = (hash * 31 + unit) & 0x7fffffff;
+    }
+    return hash;
+  }
+
+  /// 4.0 – 4.9
+  double get rating => 4 + (_seed % 10) / 10;
+
+  /// 5 – 249
+  int get reviewCount => 5 + _seed % 245;
+
+  /// 0.3 – 4.9 km
+  double get distanceKm => (3 + _seed % 47) / 10;
+
+  String get ratingLabel => rating.toStringAsFixed(1);
+
+  String get distanceLabel => '${distanceKm.toStringAsFixed(1)} km';
+}
+
+/// Placeholder per-category place counts for the category chips + eyebrow,
+/// until the backend exposes real aggregates. Deterministic from category value.
+final class CategoryCountMock {
+  const CategoryCountMock._();
+
+  static int forValue(int value) => 8 + value.abs() % 40;
+
+  static int total(Iterable<int> values) =>
+      values.fold(0, (sum, value) => sum + forValue(value));
+}

--- a/lib/product/widget/card/general_place_card.dart
+++ b/lib/product/widget/card/general_place_card.dart
@@ -1,13 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:kartal/kartal.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:life_shared/life_shared.dart';
-import 'package:lifeclient/product/model/enum/text_field/text_field_max_lengths.dart';
+import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/core/theme/app_shadows.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
 import 'package:lifeclient/product/package/image/custom_network_image.dart';
-import 'package:lifeclient/product/utility/decorations/index.dart';
+import 'package:lifeclient/product/utility/extension/category_visual.dart';
 import 'package:lifeclient/product/utility/extension/store_model_etension.dart';
+import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
+import 'package:lifeclient/product/utility/mock/place_meta_mock.dart';
 import 'package:lifeclient/product/widget/button/favorite_button/favorite_place_button.dart';
-import 'package:lifeclient/product/widget/general/index.dart';
-import 'package:lifeclient/product/widget/spacer/dynamic_vertical_spacer.dart';
+import 'package:lifeclient/product/widget/pill/status_pill.dart';
+import 'package:lifeclient/product/widget/rating/place_rating_label.dart';
 
 @immutable
 final class GeneralPlaceCard extends StatelessWidget {
@@ -17,25 +23,125 @@ final class GeneralPlaceCard extends StatelessWidget {
     super.key,
   });
 
+  static const double _imageWidth = 104;
+
   final VoidCallback onCardTap;
   final StoreModel storeModel;
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onCardTap,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        border: Border.all(color: AppColors.ink50),
+        boxShadow: AppShadows.card,
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        child: InkWell(
+          onTap: onCardTap,
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(
+                  width: _imageWidth,
+                  child: _PlaceImageBlock(model: storeModel),
+                ),
+                Expanded(child: _Body(model: storeModel)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _PlaceImageBlock extends StatelessWidget {
+  const _PlaceImageBlock({required this.model});
+
+  final StoreModel model;
+
+  @override
+  Widget build(BuildContext context) {
+    final image = model.images.firstOrNull;
+    final accent = CategoryVisual.accentFor(model.category);
+    if (image == null || image.isEmpty) {
+      return _MosaicPlaceholder(accent: accent, category: model.category);
+    }
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        CustomNetworkImage(imageUrl: image, fit: BoxFit.cover),
+        Positioned(
+          left: AppSpacing.xs,
+          bottom: AppSpacing.xs,
+          child: _CategoryGlassLabel(category: model.category),
+        ),
+      ],
+    );
+  }
+}
+
+final class _MosaicPlaceholder extends StatelessWidget {
+  const _MosaicPlaceholder({required this.accent, required this.category});
+
+  final Color accent;
+  final CategoryModel? category;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [accent, AppColors.navy],
+        ),
+      ),
+      child: Center(
+        child: Icon(
+          CategoryVisual.iconFor(category),
+          color: AppColors.white,
+          size: 36,
+        ),
+      ),
+    );
+  }
+}
+
+final class _CategoryGlassLabel extends StatelessWidget {
+  const _CategoryGlassLabel({required this.category});
+
+  final CategoryModel? category;
+
+  @override
+  Widget build(BuildContext context) {
+    final name = category?.displayName;
+    if (name == null || name.isEmpty) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.xxs,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.navy.withValues(alpha: 0.78),
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          _Image(
-            imageUrl: storeModel.images.firstOrNull,
+          Icon(
+            CategoryVisual.iconFor(category),
+            color: AppColors.white,
+            size: 12,
           ),
-          const VerticalSpace.xSmall(),
-          _TitleRow(
-            model: storeModel,
-          ),
-          _Description(
-            description: storeModel.description,
+          const SizedBox(width: AppSpacing.xxs),
+          Text(
+            name,
+            style: AppText.micro.copyWith(color: AppColors.white),
           ),
         ],
       ),
@@ -43,68 +149,75 @@ final class GeneralPlaceCard extends StatelessWidget {
   }
 }
 
-final class _Image extends StatelessWidget {
-  const _Image({
-    required this.imageUrl,
-  });
-
-  final String? imageUrl;
-
-  @override
-  Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: CustomRadius.medium,
-      child: SizedBox(
-        height: context.sized.dynamicHeight(.25),
-        child: Hero(
-          tag: imageUrl ?? '',
-          child: CustomNetworkImage(
-            imageUrl: imageUrl,
-            fit: BoxFit.cover,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-final class _TitleRow extends StatelessWidget {
-  const _TitleRow({
-    required this.model,
-  });
+class _Body extends ConsumerWidget with AppProviderStateMixin {
+  const _Body({required this.model});
 
   final StoreModel model;
 
   @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        Expanded(
-          child: GeneralContentTitle(
-            value: model.updatedName,
-            fontWeight: FontWeight.bold,
-            maxLine: TextFieldMaxLengths.maxLineForText,
-          ),
-        ),
-        FavoritePlaceButton(store: model),
-      ],
-    );
-  }
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final town = productProvider(ref).fetchTownFromCode(model.townCode);
+    final meta = PlaceMetaMock(model);
+    final category = model.category?.displayName;
+    final subtitle = [
+      if (category != null && category.isNotEmpty) category,
+      if (town.isNotEmpty) town,
+    ].join(' · ');
 
-final class _Description extends StatelessWidget {
-  const _Description({required this.description});
-
-  final String? description;
-
-  @override
-  Widget build(BuildContext context) {
     return Padding(
-      padding: const PagePadding.vertical6Symmetric(),
-      child: GeneralContentSubTitle(
-        value: description ?? '',
-        maxLine: 2,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  model.updatedName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppText.bodyLg.copyWith(
+                    color: AppColors.navy,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              FavoritePlaceButton(store: model),
+            ],
+          ),
+          if (subtitle.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.xxs),
+              child: Text(
+                subtitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppText.caption.copyWith(color: AppColors.ink400),
+              ),
+            ),
+          const SizedBox(height: AppSpacing.xs),
+          Wrap(
+            spacing: AppSpacing.sm,
+            runSpacing: AppSpacing.xxs,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              StatusPill(store: model),
+              PlaceRatingLabel(
+                rating: meta.ratingLabel,
+                reviewCount: meta.reviewCount,
+              ),
+              Text(
+                meta.distanceLabel,
+                style: AppText.caption.copyWith(color: AppColors.ink400),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/product/widget/card/place/general_place_grid_card.dart
+++ b/lib/product/widget/card/place/general_place_grid_card.dart
@@ -2,16 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/core/theme/app_colors.dart';
-import 'package:lifeclient/product/model/enum/text_field/text_field_max_lengths.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/core/theme/app_shadows.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
 import 'package:lifeclient/product/package/image/custom_network_image.dart';
-import 'package:lifeclient/product/utility/constants/app_icon_sizes.dart';
-import 'package:lifeclient/product/utility/constants/index.dart';
-import 'package:lifeclient/product/utility/decorations/index.dart';
+import 'package:lifeclient/product/utility/extension/category_visual.dart';
 import 'package:lifeclient/product/utility/extension/store_model_etension.dart';
 import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
+import 'package:lifeclient/product/utility/mock/place_meta_mock.dart';
 import 'package:lifeclient/product/widget/button/favorite_button/favorite_place_button.dart';
-import 'package:lifeclient/product/widget/general/index.dart';
-import 'package:lifeclient/product/widget/general/title/general_body_small_title.dart';
+import 'package:lifeclient/product/widget/rating/place_rating_label.dart';
 
 @immutable
 final class GeneralPlaceGridCard extends StatelessWidget {
@@ -30,36 +31,40 @@ final class GeneralPlaceGridCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      onTap: onCardTap,
-      child: Card(
-        elevation: elevation,
-        child: ClipRRect(
-          borderRadius: CustomRadius.medium,
-          child: Stack(
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        border: Border.all(color: AppColors.ink50),
+        boxShadow: AppShadows.card,
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        child: InkWell(
+          onTap: onCardTap,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Positioned.fill(
-                child: Column(
+              Expanded(
+                child: Stack(
+                  fit: StackFit.expand,
                   children: [
-                    Expanded(
-                      child: _Image(
-                        imageUrl: storeModel.images.firstOrNull,
+                    _GridImage(model: storeModel),
+                    if (isEnabledToFavorite)
+                      Positioned(
+                        top: AppSpacing.xs,
+                        right: AppSpacing.xs,
+                        child: _FavoriteCircle(store: storeModel),
                       ),
+                    Positioned(
+                      left: AppSpacing.xs,
+                      bottom: AppSpacing.xs,
+                      child: _CategoryGlassLabel(category: storeModel.category),
                     ),
-                    _TitleRow(model: storeModel),
                   ],
                 ),
               ),
-              if (isEnabledToFavorite)
-                Positioned(
-                  top: WidgetSizes.spacingXSs,
-                  right: WidgetSizes.spacingXSs,
-                  child: CircleAvatar(
-                    radius: CustomCircleRadius.medium,
-                    backgroundColor: AppColors.surface.withAlpha(200),
-                    child: FavoritePlaceButton(store: storeModel),
-                  ),
-                ),
+              _GridBody(model: storeModel),
             ],
           ),
         ),
@@ -68,53 +73,141 @@ final class GeneralPlaceGridCard extends StatelessWidget {
   }
 }
 
-final class _Image extends StatelessWidget {
-  const _Image({
-    required this.imageUrl,
-  });
+final class _GridImage extends StatelessWidget {
+  const _GridImage({required this.model});
 
-  final String? imageUrl;
+  final StoreModel model;
 
   @override
   Widget build(BuildContext context) {
-    return Hero(
-      tag: imageUrl ?? '',
-      child: CustomNetworkImage(
-        imageUrl: imageUrl,
-        fit: BoxFit.cover,
+    final image = model.images.firstOrNull;
+    final accent = CategoryVisual.accentFor(model.category);
+    if (image == null || image.isEmpty) {
+      return DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [accent, AppColors.navy],
+          ),
+        ),
+        child: Center(
+          child: Icon(
+            CategoryVisual.iconFor(model.category),
+            color: AppColors.white,
+            size: 36,
+          ),
+        ),
+      );
+    }
+    return CustomNetworkImage(imageUrl: image, fit: BoxFit.cover);
+  }
+}
+
+final class _FavoriteCircle extends StatelessWidget {
+  const _FavoriteCircle({required this.store});
+
+  final StoreModel store;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.xxs),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        shape: BoxShape.circle,
+        boxShadow: AppShadows.card,
+      ),
+      child: FavoritePlaceButton(store: store),
+    );
+  }
+}
+
+final class _CategoryGlassLabel extends StatelessWidget {
+  const _CategoryGlassLabel({required this.category});
+
+  final CategoryModel? category;
+
+  @override
+  Widget build(BuildContext context) {
+    final name = category?.displayName;
+    if (name == null || name.isEmpty) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.xxs,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.navy.withValues(alpha: 0.78),
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            CategoryVisual.iconFor(category),
+            color: AppColors.white,
+            size: 12,
+          ),
+          const SizedBox(width: AppSpacing.xxs),
+          Text(
+            name,
+            style: AppText.micro.copyWith(color: AppColors.white),
+          ),
+        ],
       ),
     );
   }
 }
 
-class _TitleRow extends ConsumerWidget with AppProviderStateMixin {
-  const _TitleRow({
-    required this.model,
-  });
+class _GridBody extends ConsumerWidget with AppProviderStateMixin {
+  const _GridBody({required this.model});
 
   final StoreModel model;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final town = productProvider(ref).fetchTownFromCode(model.townCode);
-
+    final meta = PlaceMetaMock(model);
     return Padding(
-      padding: const PagePadding.allLow(),
+      padding: const EdgeInsets.all(AppSpacing.xs),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          GeneralBodyTitle(
+          Text(
             model.updatedName,
-            maxLines: TextFieldMaxLengths.minLine,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppText.body.copyWith(
+              color: AppColors.navy,
+              fontWeight: FontWeight.w800,
+            ),
           ),
+          const SizedBox(height: AppSpacing.xxs),
           Row(
             children: [
-              const Icon(AppIcons.location, size: AppIconSizes.smallX),
-              GeneralBodySmallTitle(
-                town,
-                fontWeight: FontWeight.w400,
+              const Icon(
+                Icons.location_on,
+                size: 12,
+                color: AppColors.ink400,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              Expanded(
+                child: Text(
+                  town,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppText.caption.copyWith(color: AppColors.ink400),
+                ),
               ),
             ],
+          ),
+          const SizedBox(height: AppSpacing.xxs),
+          PlaceRatingLabel(
+            rating: meta.ratingLabel,
+            reviewCount: meta.reviewCount,
+            iconSize: 13,
           ),
         ],
       ),

--- a/lib/product/widget/pill/status_pill.dart
+++ b/lib/product/widget/pill/status_pill.dart
@@ -1,0 +1,76 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+
+/// Open/closed status pill driven by [StoreModelHelper.isStoreOpen].
+///
+/// Renders a colored dot + label (olive when open, coral when closed) and,
+/// when [showHours] is true and the store has hours, the `open – close` range.
+/// Renders nothing when the store has no parseable working hours.
+final class StatusPill extends StatelessWidget {
+  const StatusPill({required this.store, this.showHours = true, super.key});
+
+  final StoreModel store;
+  final bool showHours;
+
+  @override
+  Widget build(BuildContext context) {
+    final isOpen = StoreModelHelper(model: store).isStoreOpen;
+    if (isOpen == null) return const SizedBox.shrink();
+
+    final color = isOpen ? AppColors.olive600 : AppColors.coral600;
+    final background = isOpen ? AppColors.olive50 : AppColors.coral50;
+    final label = isOpen
+        ? LocaleKeys.placeDetailView_nowOpen.tr()
+        : LocaleKeys.placeDetailView_nowClose.tr();
+    final hours = _hours;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.xxs,
+      ),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: AppSpacing.xs,
+            height: AppSpacing.xs,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: AppSpacing.xxs),
+          Flexible(
+            child: Text(
+              hours == null ? label : '$label · $hours',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppText.micro.copyWith(
+                color: color,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String? get _hours {
+    if (!showHours) return null;
+    final open = store.openTime;
+    final close = store.closeTime;
+    if (open == null || open.isEmpty || close == null || close.isEmpty) {
+      return null;
+    }
+    return '$open – $close';
+  }
+}

--- a/lib/product/widget/rating/place_rating_label.dart
+++ b/lib/product/widget/rating/place_rating_label.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
+
+/// Gold star + rating value, with an optional grey `(reviewCount)`.
+///
+/// The value is passed in (currently placeholder data via `PlaceMetaMock`)
+/// so this widget stays presentation-only.
+final class PlaceRatingLabel extends StatelessWidget {
+  const PlaceRatingLabel({
+    required this.rating,
+    this.reviewCount,
+    this.iconSize = 15,
+    super.key,
+  });
+
+  final String rating;
+  final int? reviewCount;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.star_rounded, size: iconSize, color: AppColors.gold300),
+        const SizedBox(width: AppSpacing.xxs),
+        Text(
+          rating,
+          style: AppText.bodySm.copyWith(
+            color: AppColors.navy,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        if (reviewCount != null) ...[
+          const SizedBox(width: AppSpacing.xxs),
+          Text(
+            '($reviewCount)',
+            style: AppText.caption.copyWith(color: AppColors.ink400),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/product/widget/sheet/place_sort_sheet.dart
+++ b/lib/product/widget/sheet/place_sort_sheet.dart
@@ -1,0 +1,139 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+import 'package:lifeclient/product/model/enum/sorting_types.dart';
+import 'package:lifeclient/product/utility/constants/app_icons.dart';
+
+/// Single-select "Sırala" bottom sheet. Returns the chosen [SortingTypes] or
+/// null when dismissed.
+final class PlaceSortSheet extends StatelessWidget {
+  const PlaceSortSheet({required this.current, super.key});
+
+  final SortingTypes current;
+
+  static Future<SortingTypes?> show(
+    BuildContext context, {
+    required SortingTypes current,
+  }) {
+    return showModalBottomSheet<SortingTypes>(
+      context: context,
+      backgroundColor: AppColors.surface,
+      shape: RoundedRectangleBorder(borderRadius: AppRadius.sheet),
+      builder: (_) => PlaceSortSheet(current: current),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const _SheetHandle(),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.xl,
+              AppSpacing.xs,
+              AppSpacing.sm,
+              AppSpacing.xs,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  LocaleKeys.sorting_title.tr(),
+                  style: AppText.title.copyWith(fontSize: 18),
+                ),
+                IconButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  icon: const Icon(AppIcons.close, color: AppColors.ink500),
+                ),
+              ],
+            ),
+          ),
+          for (final type in SortingTypes.values)
+            _SortRow(
+              type: type,
+              isActive: type == current,
+              onTap: () => Navigator.of(context).pop(type),
+            ),
+          const SizedBox(height: AppSpacing.xs),
+        ],
+      ),
+    );
+  }
+}
+
+final class _SheetHandle extends StatelessWidget {
+  const _SheetHandle();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 36,
+      height: 4,
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+      decoration: BoxDecoration(
+        color: AppColors.ink200,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+      ),
+    );
+  }
+}
+
+final class _SortRow extends StatelessWidget {
+  const _SortRow({
+    required this.type,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  final SortingTypes type;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: DecoratedBox(
+        decoration: const BoxDecoration(
+          border: Border(bottom: BorderSide(color: AppColors.ink50)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.xl,
+            vertical: AppSpacing.md,
+          ),
+          child: Row(
+            children: [
+              Icon(
+                isActive ? AppIcons.check : type.icon,
+                color: isActive ? AppColors.coral : AppColors.ink500,
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Text(
+                  type.detail.tr(),
+                  style: AppText.body.copyWith(
+                    color: isActive ? AppColors.navy : AppColors.ink700,
+                    fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
+                    fontSize: 15,
+                  ),
+                ),
+              ),
+              const Icon(
+                AppIcons.rightSelect,
+                color: AppColors.ink300,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/sub_feature/advertisement_board/views/advertisement_board_item.dart
+++ b/lib/sub_feature/advertisement_board/views/advertisement_board_item.dart
@@ -9,11 +9,12 @@ final class _AdvertisementItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: () async => _onPressed(context),
-      child: FittedBox(
-        child: ClipRRect(
-          borderRadius: CustomRadius.large,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppRadius.xl),
+        child: SizedBox.expand(
           child: CustomNetworkImage(
             imageUrl: item.image,
+            fit: BoxFit.cover,
           ),
         ),
       ),
@@ -29,6 +30,120 @@ final class _AdvertisementItem extends StatelessWidget {
     return showModalBottomSheet<void>(
       builder: (_) => _AdvertisementDetailView(item),
       context: context,
+    );
+  }
+}
+
+final class _HouseAdCard extends StatelessWidget {
+  const _HouseAdCard();
+
+  static const String _contactEmail = 'medya@hatayiyasat.app';
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.coral,
+        borderRadius: BorderRadius.circular(AppRadius.xl),
+        boxShadow: AppShadows.card,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              LocaleKeys.advertisementBoard_houseAdTitle.tr(),
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: AppText.label.copyWith(
+                color: AppColors.white,
+                fontSize: 20,
+                height: 1.05,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+            Text(
+              LocaleKeys.advertisementBoard_houseAdSubtitle.tr(),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: AppText.caption.copyWith(
+                color: AppColors.white.withValues(alpha: 0.9),
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                _ContactButton(onTap: _launchContact),
+                const _HouseAdLogo(),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _launchContact() async {
+    await launchUrl(Uri(scheme: 'mailto', path: _contactEmail));
+  }
+}
+
+final class _ContactButton extends StatelessWidget {
+  const _ContactButton({required this.onTap});
+
+  final Future<void> Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.white,
+      borderRadius: BorderRadius.circular(AppRadius.pill),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.sm,
+            vertical: AppSpacing.xs,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.campaign_outlined,
+                size: 18,
+                color: AppColors.coral,
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              Text(
+                LocaleKeys.advertisementBoard_contactUs.tr(),
+                style: AppText.label.copyWith(color: AppColors.coral),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _HouseAdLogo extends StatelessWidget {
+  const _HouseAdLogo();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      padding: const EdgeInsets.all(AppSpacing.xxs),
+      decoration: BoxDecoration(
+        color: AppColors.gold300,
+        borderRadius: BorderRadius.circular(AppRadius.sm),
+      ),
+      child: Assets.icons.icAppTransparent.image(fit: BoxFit.contain),
     );
   }
 }

--- a/lib/sub_feature/advertisement_board/views/advertisement_slider.dart
+++ b/lib/sub_feature/advertisement_board/views/advertisement_slider.dart
@@ -1,14 +1,22 @@
 import 'package:carousel_slider/carousel_slider.dart';
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kartal/kartal.dart';
 import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/core/theme/app_shadows.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
+import 'package:lifeclient/product/generated/assets.gen.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/package/image/custom_network_image.dart';
 import 'package:lifeclient/product/utility/carousel/custom_carousel_options.dart';
-import 'package:lifeclient/product/utility/decorations/custom_radius.dart';
 import 'package:lifeclient/product/widget/button/open_url_general_button.dart';
 import 'package:lifeclient/product/widget/button/share_advertisement_general_button.dart';
 import 'package:lifeclient/sub_feature/advertisement_board/provider/advertisement_board_view_model.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 part 'advertisement_board_item.dart';
 part 'advertisement_detail_view.dart';
@@ -23,36 +31,69 @@ final class AdvertisementSlider extends ConsumerStatefulWidget {
 
 final class _AdvertisementSliderState extends ConsumerState<AdvertisementSlider>
     with _AdvertisementSliderStateMixin {
+  static const double _sliderHeight = 178;
+  int _current = 0;
+
   @override
   Widget build(BuildContext context) {
     final items = ref.watch(advertisementBoardViewModelProvider).advertisements;
+    final pageCount = items.length + 1;
     return SliverPadding(
       padding: const PagePadding.onlyTop(),
-      sliver: _buildSlider(context, items).ext.sliver,
+      sliver: SliverToBoxAdapter(
+        child: Column(
+          children: [
+            CarouselSlider.builder(
+              itemCount: pageCount,
+              itemBuilder: (context, index, realIndex) {
+                final child =
+                    index == 0 ? const _HouseAdCard() : _AdvertisementItem(
+                        items[index - 1],
+                      );
+                return Padding(
+                  padding: const PagePadding.horizontalLowSymmetric(),
+                  child: child,
+                );
+              },
+              options: CustomCarouselOptions.advertisement(
+                height: _sliderHeight,
+                onPageChanged: (index, reason) {
+                  setState(() => _current = index);
+                },
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            _AdvertisementDots(count: pageCount, current: _current),
+          ],
+        ),
+      ),
     );
   }
+}
 
-  Widget _buildSlider(
-    BuildContext context,
-    List<AdBoardModel> items,
-  ) {
-    if (items.isEmpty) {
-      return const SizedBox.shrink();
-    }
+final class _AdvertisementDots extends StatelessWidget {
+  const _AdvertisementDots({required this.count, required this.current});
 
-    return CarouselSlider.builder(
-      itemBuilder: (context, index, realIndex) {
-        return _buildItem(context, items[index]);
-      },
-      itemCount: items.length,
-      options: CustomCarouselOptions.advertisement(),
-    );
-  }
+  final int count;
+  final int current;
 
-  Padding _buildItem(BuildContext context, AdBoardModel item) {
-    return Padding(
-      padding: const PagePadding.horizontalLowSymmetric(),
-      child: _AdvertisementItem(item),
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        for (var index = 0; index < count; index++)
+          AnimatedContainer(
+            duration: Durations.short4,
+            margin: const EdgeInsets.symmetric(horizontal: 3),
+            width: index == current ? 18 : 6,
+            height: 6,
+            decoration: BoxDecoration(
+              color: index == current ? AppColors.coral : AppColors.ink200,
+              borderRadius: BorderRadius.circular(AppRadius.pill),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/sub_feature/main_tab/main_tab_view.dart
+++ b/lib/sub_feature/main_tab/main_tab_view.dart
@@ -1,11 +1,15 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hugeicons/hugeicons.dart';
 import 'package:kartal/kartal.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/core/dependency/project_dependency_items.dart';
+import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
 import 'package:lifeclient/core/theme/app_shadows.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/core/theme/app_text.dart';
+import 'package:lifeclient/product/generated/assets.gen.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/navigation/app_router.dart';
 import 'package:lifeclient/product/utility/constants/app_constants.dart';
@@ -14,7 +18,6 @@ import 'package:lifeclient/product/utility/mixin/index.dart';
 import 'package:lifeclient/product/widget/general/semantics/general_semantic.dart';
 import 'package:lifeclient/product/widget/general/semantics/general_semantic_keys.dart';
 import 'package:lifeclient/product/widget/general/title/general_content_sub_title.dart';
-import 'package:lifeclient/product/widget/general/title/general_sub_title.dart';
 import 'package:lifeclient/product/widget/sheet/regional/regional_city_sheet.dart';
 import 'package:lifeclient/product/widget/speed_dial/custom_speed_dial.dart';
 import 'package:lifeclient/product/widget/speed_dial/custom_speed_dial_child.dart';
@@ -36,7 +39,7 @@ final class MainTabView extends ConsumerStatefulWidget {
 
 class _MainTabViewState extends ConsumerState<MainTabView>
     with TickerProviderStateMixin, AppProviderMixin, MainTabViewMixin {
-  final _tabItems = TabModels.create().tabItems;
+  final List<TabModel> _tabItems = TabModels.create().tabItems;
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +54,7 @@ class _MainTabViewState extends ConsumerState<MainTabView>
           length: _tabItems.length,
           child: Scaffold(
             extendBody: true,
-            appBar: _MainAppBar(context: context),
+            appBar: _MainAppBar(),
             floatingActionButtonLocation:
                 FloatingActionButtonLocation.centerDocked,
             body: _BodyTabBarViewWidget(tabItems: _tabItems),

--- a/lib/sub_feature/main_tab/widget/main_app_bar.dart
+++ b/lib/sub_feature/main_tab/widget/main_app_bar.dart
@@ -1,9 +1,7 @@
 part of '../main_tab_view.dart';
 
 final class _MainAppBar extends AppBar {
-  _MainAppBar({
-    required BuildContext context,
-  }) : super(
+  _MainAppBar() : super(
          bottom: PreferredSize(
            preferredSize: const Size.fromHeight(WidgetSizes.spacingS),
            child: Divider(
@@ -12,54 +10,116 @@ final class _MainAppBar extends AppBar {
          ),
          automaticallyImplyLeading: false,
          centerTitle: false,
-         title: TextButton(
-           style: TextButton.styleFrom(
-             padding: EdgeInsets.zero,
-           ),
-           onPressed: () async {
-             final result = await RegionalCitySheet.show(context);
-             if (result == null) return;
-             ProjectDependencyItems.productProvider.saveSelectedCity(result);
-           },
-           child: Row(
-             mainAxisSize: MainAxisSize.min,
-             spacing: WidgetSizes.spacingXSs,
-             children: [
-               HugeIcon(
-                 icon: HugeIcons.strokeRoundedArrowDown01,
-                 color: context.general.colorScheme.primary,
-               ),
-               const _AppBarTitle(),
-             ],
-           ),
+         titleSpacing: AppSpacing.lg,
+         title: Row(
+           mainAxisSize: MainAxisSize.min,
+           children: [
+             Assets.icons.icAppTransparent.image(
+               height: WidgetSizes.spacingXxl,
+               width: WidgetSizes.spacingXxl,
+             ),
+             const SizedBox(width: AppSpacing.sm),
+             const _CityPill(),
+           ],
          ),
-         actions: [
-           IconButton(
-             onPressed: () {
-               const NotificationsRoute().go(context);
-             },
-             icon: const Icon(AppIcons.notifications),
-           ),
-           IconButton(
-             onPressed: () async {
-               await const SettingsRoute().push<void>(context);
-             },
-             icon: const Icon(AppIcons.settings),
-           ),
-           const _CustomPopupMenu(),
+         actions: const [
+           _NotificationButton(),
+           _SettingsButton(),
+           _CustomPopupMenu(),
+           SizedBox(width: AppSpacing.xxs),
          ],
        );
 }
 
-final class _AppBarTitle extends ConsumerWidget {
-  const _AppBarTitle();
+final class _CityPill extends ConsumerWidget {
+  const _CityPill();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentCity = ref.watch(ProjectDependencyItems.productProviderState);
-    return GeneralSubTitle(
-      value: currentCity.selectedCity.description,
-      fontWeight: FontWeight.bold,
+    return Material(
+      color: AppColors.coral50,
+      borderRadius: BorderRadius.circular(AppRadius.pill),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+        onTap: () async {
+          final result = await RegionalCitySheet.show(context);
+          if (result == null) return;
+          ProjectDependencyItems.productProvider.saveSelectedCity(result);
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.sm,
+            vertical: AppSpacing.xs,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                AppIcons.location,
+                size: WidgetSizes.spacingMx,
+                color: AppColors.coral,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              Text(
+                currentCity.selectedCity.description,
+                style: AppText.label.copyWith(color: AppColors.coral700),
+              ),
+              const Icon(
+                Icons.keyboard_arrow_down_rounded,
+                size: WidgetSizes.spacingL,
+                color: AppColors.coral,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _NotificationButton extends StatelessWidget {
+  const _NotificationButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        IconButton(
+          onPressed: () {
+            const NotificationsRoute().go(context);
+          },
+          icon: const Icon(AppIcons.notifications),
+        ),
+        Positioned(
+          top: WidgetSizes.spacingS,
+          right: WidgetSizes.spacingS,
+          child: Container(
+            width: WidgetSizes.spacingXs,
+            height: WidgetSizes.spacingXs,
+            decoration: BoxDecoration(
+              color: AppColors.coral,
+              shape: BoxShape.circle,
+              border: Border.all(color: AppColors.surface, width: 1.5),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+final class _SettingsButton extends StatelessWidget {
+  const _SettingsButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: () async {
+        await const SettingsRoute().push<void>(context);
+      },
+      icon: const Icon(AppIcons.settings),
     );
   }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive filtering system to the home view, enhances sorting and search UI, and adds new translation keys for both English and Turkish. The changes include significant updates to state management, Firestore querying, and the user interface, enabling users to filter places by categories, districts, open status, and favorites, as well as sort results and see live result counts.

### Filtering and Sorting Functionality

- **Home State and ViewModel:**  
  - Added filter-related fields (`categoryValues`, `townCodes`, `openNow`, `favoritesOnly`) and helper getters to `HomeState` for tracking filter selections. Updated `copyWith` and `props` accordingly.
  - Refactored `HomeViewModel` to support building Firestore queries with server-side filtering for categories and districts, and client-side filtering for open/favorites. Added methods for applying/clearing filters, single-category selection, and live result counting. [[1]](diffhunk://#diff-c13c2e86188eceb0f134c645ec6d147b3e86a6cea8a198fc2075e31ff82f7753L34-R76) [[2]](diffhunk://#diff-c13c2e86188eceb0f134c645ec6d147b3e86a6cea8a198fc2075e31ff82f7753L59-R191)

- **UI Enhancements:**  
  - Refactored the home view to include a new header block, a search/filter row, and an active filter bar. Added a filter button that opens a new filter sheet and displays an indicator when filters are active.
  - Improved the search field to be read-only, styled it with new colors and borders, and updated its behavior to launch the search delegate.

### Localization

- **Translation Keys:**  
  - Added new keys for filter and sorting UI, including support for all filter options, sorting labels, and filter result counts in both English and Turkish translation files (`en.json`, `tr.json`). [[1]](diffhunk://#diff-6728fa8c02dfa32f3b21cfff90497292749e03d668ccd32202eee82b5596462fL115-R117) [[2]](diffhunk://#diff-6728fa8c02dfa32f3b21cfff90497292749e03d668ccd32202eee82b5596462fR308-R313) [[3]](diffhunk://#diff-6728fa8c02dfa32f3b21cfff90497292749e03d668ccd32202eee82b5596462fL314-R325) [[4]](diffhunk://#diff-6728fa8c02dfa32f3b21cfff90497292749e03d668ccd32202eee82b5596462fR393-R410) [[5]](diffhunk://#diff-30b467e1d38ef42623622e77be1fee9e62976dfd3e2657e3b482d2d2d9e1dcdcL115-R117) [[6]](diffhunk://#diff-30b467e1d38ef42623622e77be1fee9e62976dfd3e2657e3b482d2d2d9e1dcdcR308-R313) [[7]](diffhunk://#diff-30b467e1d38ef42623622e77be1fee9e62976dfd3e2657e3b482d2d2d9e1dcdcL314-R325) [[8]](diffhunk://#diff-30b467e1d38ef42623622e77be1fee9e62976dfd3e2657e3b482d2d2d9e1dcdcR393-R410)

### Code Organization

- **Imports and Dependencies:**  
  - Cleaned up and updated imports to support new features, including the filter sheet, sorting sheet, and utility extensions.

---

**References:**  
[[1]](diffhunk://#diff-2289b49083b8407c98012c90415a5bc8b50928f16cb338e9718accd194837356R11-R75) [[2]](diffhunk://#diff-c13c2e86188eceb0f134c645ec6d147b3e86a6cea8a198fc2075e31ff82f7753L34-R76) [[3]](diffhunk://#diff-c13c2e86188eceb0f134c645ec6d147b3e86a6cea8a198fc2075e31ff82f7753L59-R191) [[4]](diffhunk://#diff-e31cd45a2c94c41b4a3653e03aeca8976e1a95a5fc55d43c68c46938a62e6470L60-R190) [[5]](diffhunk://#diff-e31cd45a2c94c41b4a3653e03aeca8976e1a95a5fc55d43c68c46938a62e6470R203-R226) [[6]](diffhunk://#diff-6728fa8c02dfa32f3b21cfff90497292749e03d668ccd32202eee82b5596462fL115-R117) [[7]](diffhunk://#diff-6728fa8c02dfa32f3b21cfff90497292749e03d668ccd32202eee82b5596462fR308-R313) [[8]](diffhunk://#diff-6728fa8c02dfa32f3b21cfff90497292749e03d668ccd32202eee82b5596462fL314-R325) [[9]](diffhunk://#diff-6728fa8c02dfa32f3b21cfff90497292749e03d668ccd32202eee82b5596462fR393-R410) [[10]](diffhunk://#diff-30b467e1d38ef42623622e77be1fee9e62976dfd3e2657e3b482d2d2d9e1dcdcL115-R117) [[11]](diffhunk://#diff-30b467e1d38ef42623622e77be1fee9e62976dfd3e2657e3b482d2d2d9e1dcdcR308-R313) [[12]](diffhunk://#diff-30b467e1d38ef42623622e77be1fee9e62976dfd3e2657e3b482d2d2d9e1dcdcL314-R325) [[13]](diffhunk://#diff-30b467e1d38ef42623622e77be1fee9e62976dfd3e2657e3b482d2d2d9e1dcdcR393-R410) [[14]](diffhunk://#diff-e31cd45a2c94c41b4a3653e03aeca8976e1a95a5fc55d43c68c46938a62e6470L5-R32)