### PR TITLE
feat(community): add group domain models and mock data

### DIFF
--- a/lib/features/community/mock/community_mock_data.dart
+++ b/lib/features/community/mock/community_mock_data.dart
@@ -1,0 +1,290 @@
+import 'package:lifeclient/features/community/model/group_category_model.dart';
+import 'package:lifeclient/features/community/model/group_discussion_entry_model.dart';
+import 'package:lifeclient/features/community/model/group_discussion_model.dart';
+import 'package:lifeclient/features/community/model/group_member_model.dart';
+import 'package:lifeclient/features/community/model/group_member_role.dart';
+import 'package:lifeclient/features/community/model/group_model.dart';
+import 'package:lifeclient/features/community/model/group_post_model.dart';
+import 'package:lifeclient/features/community/model/group_type.dart';
+
+/// Community feature'ının tek mock veri kaynağı.
+// TODO(community): Firestore bağlanınca bu dosya silinecek.
+final class CommunityMockData {
+  const CommunityMockData._();
+
+  static const saim = GroupMemberModel(
+    id: 'mock-member-1',
+    displayName: 'Saim Yıldırım',
+    username: 'saimusta',
+    role: GroupMemberRole.admin,
+  );
+
+  static const ahmet = GroupMemberModel(
+    id: 'mock-member-2',
+    displayName: 'Ahmet Altınöz',
+    username: 'altinoz',
+    role: GroupMemberRole.admin,
+  );
+
+  static const eylem = GroupMemberModel(
+    id: 'mock-member-3',
+    displayName: 'Eylem Akdeniz',
+    username: 'eylemakdeniz',
+  );
+
+  static const zeynep = GroupMemberModel(
+    id: 'mock-member-4',
+    displayName: 'Zeynep Kara',
+    username: 'zeynepkara',
+    role: GroupMemberRole.admin,
+  );
+
+  static const mehmet = GroupMemberModel(
+    id: 'mock-member-5',
+    displayName: 'Mehmet Şanlı',
+    username: 'mehmetusta',
+    role: GroupMemberRole.admin,
+  );
+
+  static const deniz = GroupMemberModel(
+    id: 'mock-member-6',
+    displayName: 'Deniz Aydın',
+    username: 'denizaydin',
+    role: GroupMemberRole.admin,
+  );
+
+  static const hasan = GroupMemberModel(
+    id: 'mock-member-7',
+    displayName: 'Hasan Demir',
+    username: 'hasandemir',
+    role: GroupMemberRole.admin,
+  );
+
+  static const yasemin = GroupMemberModel(
+    id: 'mock-member-8',
+    displayName: 'Yasemin Ercan',
+    username: 'yaseminercan',
+  );
+
+  static const currentMember = GroupMemberModel(
+    id: 'mock-member-current',
+    displayName: 'Hatay Gönüllüsü',
+    username: 'hataygonullusu',
+  );
+
+  static const categories = [
+    GroupCategoryModel(id: 'solidarity', name: 'Dayanışma'),
+    GroupCategoryModel(id: 'tradesman', name: 'Esnaf'),
+    GroupCategoryModel(id: 'neighborhood', name: 'Mahalle'),
+    GroupCategoryModel(id: 'event', name: 'Etkinlik'),
+    GroupCategoryModel(id: 'solidarityAid', name: 'Yardımlaşma'),
+    GroupCategoryModel(id: 'culture', name: 'Kültür'),
+  ];
+
+  /// group-1: dolu, group-2: az içerik, group-3: boş, group-4: admin,
+  /// group-5: kapalı.
+  static List<GroupModel> get groups => [
+    GroupModel(
+      id: 'mock-group-1',
+      name: 'Antakya Esnaf Dayanışması',
+      description: 'Uzun Çarşı ve çevresi esnafının dayanışma ağı.',
+      memberCount: 248,
+      coverImageUrl: 'https://picsum.photos/seed/antakya-esnaf/400',
+      createdAt: DateTime(2025, 1, 12),
+      admins: const [saim, ahmet],
+    ),
+    GroupModel(
+      id: 'mock-group-2',
+      name: 'Defne Mahalle Komitesi',
+      description: 'Defne mahalleleri için yardımlaşma ve iletişim.',
+      memberCount: 96,
+      coverImageUrl: 'https://picsum.photos/seed/defne-mahalle/400',
+      createdAt: DateTime(2025, 2, 3),
+      admins: const [zeynep],
+    ),
+    GroupModel(
+      id: 'mock-group-3',
+      name: 'Künefeciler Birliği',
+      description: 'Antakya künefe ustaları — tarif ve usul paylaşımı.',
+      memberCount: 42,
+      createdAt: DateTime(2024, 11, 20),
+      admins: const [mehmet],
+    ),
+    GroupModel(
+      id: 'mock-group-4',
+      name: 'Samandağ Gönüllüleri',
+      description: 'Bölge için gönüllülük ve yardımlaşma çalışmaları.',
+      memberCount: 131,
+      coverImageUrl: 'https://picsum.photos/seed/samandag/400',
+      createdAt: DateTime(2025, 3, 8),
+      isCurrentUserAdmin: true,
+      admins: const [deniz],
+    ),
+    GroupModel(
+      id: 'mock-group-5',
+      name: 'Harbiye Üreticileri',
+      description: 'Yerel üreticiler arası kapalı iletişim ve sipariş ağı.',
+      memberCount: 57,
+      type: GroupType.closed,
+      createdAt: DateTime(2025, 4, 15),
+      admins: const [hasan],
+    ),
+  ];
+
+  static List<GroupPostModel> postsOf(String groupId) => switch (groupId) {
+    'mock-group-1' => [
+      GroupPostModel(
+        id: 'mock-post-1-1',
+        author: saim,
+        content:
+            "Cumartesi sabahı çarşı temizliği için 08:00'de buluşuyoruz. "
+            'Eldiven ve poşetleri dernek karşılıyor 🤍',
+        createdAt: DateTime.now().subtract(const Duration(hours: 2)),
+        imageUrl: 'https://picsum.photos/seed/carsi-temizlik/600/300',
+        likeCount: 34,
+        commentCount: 8,
+      ),
+      GroupPostModel(
+        id: 'mock-post-1-2',
+        author: eylem,
+        content:
+            'Yeni açtığımız stant için teşekkürler, ilk gün çok güzeldi. '
+            'Destek olan herkese minnettarız.',
+        createdAt: DateTime.now().subtract(const Duration(hours: 5)),
+        likeCount: 12,
+        commentCount: 3,
+      ),
+    ],
+    'mock-group-2' => [
+      GroupPostModel(
+        id: 'mock-post-2-1',
+        author: zeynep,
+        content:
+            'Mahalle kahvaltısı bu pazar parkta — herkes bir şey getirsin.',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        likeCount: 21,
+        commentCount: 5,
+      ),
+    ],
+    'mock-group-4' => [
+      GroupPostModel(
+        id: 'mock-post-4-1',
+        author: deniz,
+        content:
+            'Hafta sonu fidan dikimi için buluşma noktası belediye önü, '
+            '09:30.',
+        createdAt: DateTime.now().subtract(const Duration(hours: 8)),
+        likeCount: 18,
+        commentCount: 4,
+      ),
+    ],
+    'mock-group-5' => [
+      GroupPostModel(
+        id: 'mock-post-5-1',
+        author: hasan,
+        content: 'Bu haftaki sipariş listesi güncellendi, kontrol edin.',
+        createdAt: DateTime.now().subtract(const Duration(hours: 12)),
+        likeCount: 7,
+        commentCount: 2,
+      ),
+    ],
+    _ => const [],
+  };
+
+  static List<GroupDiscussionModel> discussionsOf(String groupId) =>
+      switch (groupId) {
+        'mock-group-1' => [
+          GroupDiscussionModel(
+            id: 'mock-discussion-1-1',
+            title: 'Cumartesi pazarı yeni yer düzeni',
+            author: saim,
+            createdAt: DateTime.now().subtract(const Duration(hours: 3)),
+            entries: [
+              GroupDiscussionEntryModel(
+                id: 'mock-entry-1-1-1',
+                author: saim,
+                content:
+                    'Bu konuyu açtım çünkü mevcut yerleşim dar geliyor. '
+                    'Köşe stantları ana giriş yerine yan sokağa alalım derim.',
+                createdAt: DateTime.now().subtract(const Duration(hours: 3)),
+              ),
+              GroupDiscussionEntryModel(
+                id: 'mock-entry-1-1-2',
+                author: ahmet,
+                content:
+                    'Katılıyorum. Yan sokak daha geniş ve gölge var, yazın '
+                    'daha rahat olur.',
+                createdAt: DateTime.now().subtract(const Duration(hours: 2)),
+              ),
+              GroupDiscussionEntryModel(
+                id: 'mock-entry-1-1-3',
+                author: eylem,
+                content:
+                    'Ana girişe karşılama + bilgi standı koyalım, ziyaretçi '
+                    'yönlendirmesi kolaylaşır.',
+                createdAt: DateTime.now().subtract(const Duration(hours: 1)),
+              ),
+              GroupDiscussionEntryModel(
+                id: 'mock-entry-1-1-4',
+                author: yasemin,
+                content:
+                    'Elektrik prizleri sadece duvar tarafında, o yüzden '
+                    'elektrik gerektiren standları oraya yakın planlamalıyız.',
+                createdAt: DateTime.now().subtract(
+                  const Duration(minutes: 34),
+                ),
+              ),
+            ],
+          ),
+          GroupDiscussionModel(
+            id: 'mock-discussion-1-2',
+            title: 'Ortak tedarikçi anlaşması',
+            author: ahmet,
+            createdAt: DateTime.now().subtract(const Duration(days: 1)),
+            entries: [
+              GroupDiscussionEntryModel(
+                id: 'mock-entry-1-2-1',
+                author: ahmet,
+                content:
+                    'Toplu alımda indirim almak için tek tedarikçi üzerinden '
+                    'anlaşalım mı?',
+                createdAt: DateTime.now().subtract(const Duration(days: 1)),
+              ),
+            ],
+          ),
+          GroupDiscussionModel(
+            id: 'mock-discussion-1-3',
+            title: 'Festival hazırlık komitesi',
+            author: saim,
+            createdAt: DateTime.now().subtract(const Duration(days: 2)),
+            entries: [
+              GroupDiscussionEntryModel(
+                id: 'mock-entry-1-3-1',
+                author: saim,
+                content: 'Komiteye katılmak isteyenler buraya yazsın.',
+                createdAt: DateTime.now().subtract(const Duration(days: 2)),
+              ),
+            ],
+          ),
+        ],
+        'mock-group-4' => [
+          GroupDiscussionModel(
+            id: 'mock-discussion-4-1',
+            title: 'Fidan dikimi malzeme listesi',
+            author: deniz,
+            createdAt: DateTime.now().subtract(const Duration(hours: 6)),
+            entries: [
+              GroupDiscussionEntryModel(
+                id: 'mock-entry-4-1-1',
+                author: deniz,
+                content:
+                    'Eldiven ve kürek dernekte var; su bidonunu kim '
+                    'getirebilir?',
+                createdAt: DateTime.now().subtract(const Duration(hours: 6)),
+              ),
+            ],
+          ),
+        ],
+        _ => const [],
+      };
+}

--- a/lib/features/community/model/group_category_model.dart
+++ b/lib/features/community/model/group_category_model.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+
+final class GroupCategoryModel extends Equatable {
+  const GroupCategoryModel({
+    required this.id,
+    required this.name,
+  });
+
+  final String id;
+  final String name;
+
+  @override
+  List<Object> get props => [id, name];
+}

--- a/lib/features/community/model/group_discussion_entry_model.dart
+++ b/lib/features/community/model/group_discussion_entry_model.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+import 'package:lifeclient/features/community/model/group_member_model.dart';
+
+final class GroupDiscussionEntryModel extends Equatable {
+  const GroupDiscussionEntryModel({
+    required this.id,
+    required this.author,
+    required this.content,
+    required this.createdAt,
+  });
+
+  final String id;
+  final GroupMemberModel author;
+  final String content;
+  final DateTime createdAt;
+
+  @override
+  List<Object> get props => [id, author, content, createdAt];
+}

--- a/lib/features/community/model/group_discussion_model.dart
+++ b/lib/features/community/model/group_discussion_model.dart
@@ -1,0 +1,41 @@
+import 'package:equatable/equatable.dart';
+import 'package:lifeclient/features/community/model/group_discussion_entry_model.dart';
+import 'package:lifeclient/features/community/model/group_member_model.dart';
+
+final class GroupDiscussionModel extends Equatable {
+  const GroupDiscussionModel({
+    required this.id,
+    required this.title,
+    required this.author,
+    required this.createdAt,
+    this.entries = const [],
+  });
+
+  final String id;
+  final String title;
+  final GroupMemberModel author;
+  final DateTime createdAt;
+
+  final List<GroupDiscussionEntryModel> entries;
+
+  int get entryCount => entries.length;
+
+  @override
+  List<Object> get props => [id, title, author, createdAt, entries];
+
+  GroupDiscussionModel copyWith({
+    String? id,
+    String? title,
+    GroupMemberModel? author,
+    DateTime? createdAt,
+    List<GroupDiscussionEntryModel>? entries,
+  }) {
+    return GroupDiscussionModel(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      author: author ?? this.author,
+      createdAt: createdAt ?? this.createdAt,
+      entries: entries ?? this.entries,
+    );
+  }
+}

--- a/lib/features/community/model/group_member_model.dart
+++ b/lib/features/community/model/group_member_model.dart
@@ -1,0 +1,60 @@
+import 'package:equatable/equatable.dart';
+import 'package:lifeclient/features/community/model/group_member_role.dart';
+import 'package:lifeclient/product/model/auth/app_user.dart';
+
+final class GroupMemberModel extends Equatable {
+  const GroupMemberModel({
+    required this.id,
+    required this.displayName,
+    required this.username,
+    this.avatarUrl,
+    this.role = GroupMemberRole.member,
+  });
+
+  factory GroupMemberModel.fromAppUser(AppUser user) {
+    return GroupMemberModel(
+      id: user.uid,
+      displayName: user.displayName,
+      username: user.email.split('@').first,
+      avatarUrl: user.photoUrl,
+    );
+  }
+
+  final String id;
+  final String displayName;
+  final String username;
+  final String? avatarUrl;
+  final GroupMemberRole role;
+
+  /// Tartışmalar sekmesi için isim maskesi — "Saim Yıldırım" → "S••• Y•••••".
+  String get maskedDisplayName {
+    return displayName
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((word) => word.isNotEmpty)
+        .map(
+          (word) =>
+              word.length <= 1 ? word : '${word[0]}${'•' * (word.length - 1)}',
+        )
+        .join(' ');
+  }
+
+  @override
+  List<Object?> get props => [id, displayName, username, avatarUrl, role];
+
+  GroupMemberModel copyWith({
+    String? id,
+    String? displayName,
+    String? username,
+    String? avatarUrl,
+    GroupMemberRole? role,
+  }) {
+    return GroupMemberModel(
+      id: id ?? this.id,
+      displayName: displayName ?? this.displayName,
+      username: username ?? this.username,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      role: role ?? this.role,
+    );
+  }
+}

--- a/lib/features/community/model/group_member_model.dart
+++ b/lib/features/community/model/group_member_model.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:lifeclient/features/community/model/group_member_role.dart';
 import 'package:lifeclient/product/model/auth/app_user.dart';
+import 'package:lifeclient/product/utility/constants/regex_types.dart';
 
 final class GroupMemberModel extends Equatable {
   const GroupMemberModel({
@@ -30,7 +31,7 @@ final class GroupMemberModel extends Equatable {
   String get maskedDisplayName {
     return displayName
         .trim()
-        .split(RegExp(r'\s+'))
+        .split(RegexTypes.whitespace)
         .where((word) => word.isNotEmpty)
         .map(
           (word) =>

--- a/lib/features/community/model/group_member_role.dart
+++ b/lib/features/community/model/group_member_role.dart
@@ -1,0 +1,10 @@
+enum GroupMemberRole {
+  member,
+  admin;
+
+  static GroupMemberRole fromString(String? value) =>
+      GroupMemberRole.values.firstWhere(
+        (e) => e.name == value,
+        orElse: () => GroupMemberRole.member,
+      );
+}

--- a/lib/features/community/model/group_model.dart
+++ b/lib/features/community/model/group_model.dart
@@ -1,0 +1,65 @@
+import 'package:equatable/equatable.dart';
+import 'package:lifeclient/features/community/model/group_member_model.dart';
+import 'package:lifeclient/features/community/model/group_type.dart';
+
+final class GroupModel extends Equatable {
+  const GroupModel({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.memberCount,
+    this.coverImageUrl,
+    this.type = GroupType.open,
+    this.createdAt,
+    this.admins = const [],
+    this.isCurrentUserAdmin = false,
+  });
+
+  final String id;
+  final String name;
+  final String description;
+  final int memberCount;
+  final String? coverImageUrl;
+  final GroupType type;
+  final DateTime? createdAt;
+  final List<GroupMemberModel> admins;
+
+  final bool isCurrentUserAdmin;
+
+  @override
+  List<Object?> get props => [
+    id,
+    name,
+    description,
+    memberCount,
+    coverImageUrl,
+    type,
+    createdAt,
+    admins,
+    isCurrentUserAdmin,
+  ];
+
+  GroupModel copyWith({
+    String? id,
+    String? name,
+    String? description,
+    int? memberCount,
+    String? coverImageUrl,
+    GroupType? type,
+    DateTime? createdAt,
+    List<GroupMemberModel>? admins,
+    bool? isCurrentUserAdmin,
+  }) {
+    return GroupModel(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      memberCount: memberCount ?? this.memberCount,
+      coverImageUrl: coverImageUrl ?? this.coverImageUrl,
+      type: type ?? this.type,
+      createdAt: createdAt ?? this.createdAt,
+      admins: admins ?? this.admins,
+      isCurrentUserAdmin: isCurrentUserAdmin ?? this.isCurrentUserAdmin,
+    );
+  }
+}

--- a/lib/features/community/model/group_post_model.dart
+++ b/lib/features/community/model/group_post_model.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:equatable/equatable.dart';
+import 'package:lifeclient/features/community/model/group_member_model.dart';
+
+final class GroupPostModel extends Equatable {
+  const GroupPostModel({
+    required this.id,
+    required this.author,
+    required this.content,
+    required this.createdAt,
+    this.imageUrl,
+    this.imageFile,
+    this.likeCount = 0,
+    this.commentCount = 0,
+    this.isLikedByCurrentUser = false,
+  });
+
+  final String id;
+  final GroupMemberModel author;
+  final String content;
+  final DateTime createdAt;
+  final String? imageUrl;
+
+  final File? imageFile;
+  final int likeCount;
+  final int commentCount;
+  final bool isLikedByCurrentUser;
+
+  @override
+  List<Object?> get props => [
+    id,
+    author,
+    content,
+    createdAt,
+    imageUrl,
+    imageFile,
+    likeCount,
+    commentCount,
+    isLikedByCurrentUser,
+  ];
+
+  GroupPostModel copyWith({
+    String? id,
+    GroupMemberModel? author,
+    String? content,
+    DateTime? createdAt,
+    String? imageUrl,
+    File? imageFile,
+    int? likeCount,
+    int? commentCount,
+    bool? isLikedByCurrentUser,
+  }) {
+    return GroupPostModel(
+      id: id ?? this.id,
+      author: author ?? this.author,
+      content: content ?? this.content,
+      createdAt: createdAt ?? this.createdAt,
+      imageUrl: imageUrl ?? this.imageUrl,
+      imageFile: imageFile ?? this.imageFile,
+      likeCount: likeCount ?? this.likeCount,
+      commentCount: commentCount ?? this.commentCount,
+      isLikedByCurrentUser: isLikedByCurrentUser ?? this.isLikedByCurrentUser,
+    );
+  }
+}

--- a/lib/features/community/model/group_type.dart
+++ b/lib/features/community/model/group_type.dart
@@ -1,0 +1,9 @@
+enum GroupType {
+  open,
+  closed;
+
+  static GroupType fromString(String? value) => GroupType.values.firstWhere(
+    (e) => e.name == value,
+    orElse: () => GroupType.open,
+  );
+}


### PR DESCRIPTION
#375'in bölünmüş hali — 1/5.

## Kapsam
- Community feature'ının domain modelleri: `GroupModel`, `GroupMemberModel`, `GroupPostModel`, `GroupDiscussionModel`, `GroupDiscussionEntryModel`, `GroupCategoryModel`, `GroupMemberRole`, `GroupType`
- Akış testi için tek merkezli mock veri kaynağı: `CommunityMockData` (Firestore bağlanınca komple silinecek, TODO ile işaretli)

UI içermez. Sonraki PR'lar sırasıyla: paylaşılan widget'lar → Gruplar + Grup Oluşturma → Grup Detay → Tartışma Detay.

İlgili issue: #349