### PR TITLE
feat(community): add discussion detail with entries and reply composer

### DIFF
--- a/lib/core/theme/app_context_colors.dart
+++ b/lib/core/theme/app_context_colors.dart
@@ -18,6 +18,7 @@ final class AppColorTokens {
   Color get navy700 => AppColors.navy700;
   Color get navy900 => AppColors.navy900;
   Color get ink200 => AppColors.ink200;
+  Color get ink300 => AppColors.ink300;
   Color get olive600 => AppColors.olive600;
 
   /// `colorScheme.surface`'tan farklıdır (o `AppColors.bg`'ye eşlenir);

--- a/lib/features/community/discussion_detail/model/discussion_detail_args.dart
+++ b/lib/features/community/discussion_detail/model/discussion_detail_args.dart
@@ -1,0 +1,13 @@
+import 'package:equatable/equatable.dart';
+import 'package:lifeclient/features/community/model/group_discussion_model.dart';
+import 'package:lifeclient/features/community/model/group_model.dart';
+
+final class DiscussionDetailArgs extends Equatable {
+  const DiscussionDetailArgs({required this.group, required this.discussion});
+
+  final GroupModel group;
+  final GroupDiscussionModel discussion;
+
+  @override
+  List<Object> get props => [group, discussion];
+}

--- a/lib/features/community/discussion_detail/provider/discussion_detail_state.dart
+++ b/lib/features/community/discussion_detail/provider/discussion_detail_state.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:lifeclient/features/community/model/group_discussion_entry_model.dart';
+import 'package:lifeclient/features/community/model/group_member_model.dart';
+
+@immutable
+final class DiscussionDetailState extends Equatable {
+  const DiscussionDetailState({
+    required this.entries,
+    required this.currentMember,
+    this.isFetching = false,
+    this.isError = false,
+  });
+
+  final List<GroupDiscussionEntryModel> entries;
+  final GroupMemberModel currentMember;
+  final bool isFetching;
+  final bool isError;
+
+  @override
+  List<Object?> get props => [entries, currentMember, isFetching, isError];
+
+  DiscussionDetailState copyWith({
+    List<GroupDiscussionEntryModel>? entries,
+    GroupMemberModel? currentMember,
+    bool? isFetching,
+    bool? isError,
+  }) {
+    return DiscussionDetailState(
+      entries: entries ?? this.entries,
+      currentMember: currentMember ?? this.currentMember,
+      isFetching: isFetching ?? this.isFetching,
+      isError: isError ?? this.isError,
+    );
+  }
+}

--- a/lib/features/community/discussion_detail/provider/discussion_detail_view_model.dart
+++ b/lib/features/community/discussion_detail/provider/discussion_detail_view_model.dart
@@ -1,0 +1,41 @@
+import 'package:lifeclient/core/dependency/index.dart';
+import 'package:lifeclient/features/community/discussion_detail/provider/discussion_detail_state.dart';
+import 'package:lifeclient/features/community/model/group_discussion_entry_model.dart';
+import 'package:lifeclient/features/community/model/group_discussion_model.dart';
+import 'package:lifeclient/features/community/provider/current_group_member_provider.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'discussion_detail_view_model.g.dart';
+
+@riverpod
+final class DiscussionDetailViewModel extends _$DiscussionDetailViewModel
+    with ProjectDependencyMixin {
+  static const _localIdPrefix = 'local-';
+
+  @override
+  DiscussionDetailState build() => DiscussionDetailState(
+    entries: const [],
+    currentMember: ref.read(currentGroupMemberProvider),
+    isFetching: true,
+  );
+
+  // TODO(community): Firestore servis PR'ında mock yerine gerçek istek gelecek.
+  void fetchEntries(GroupDiscussionModel discussion) {
+    state = state.copyWith(
+      entries: discussion.entries,
+      isFetching: false,
+      isError: false,
+    );
+  }
+
+  // TODO(community): Firestore servis PR'ında gönderi sunucuya yazılacak.
+  void addEntry(String content) {
+    final entry = GroupDiscussionEntryModel(
+      id: '$_localIdPrefix${DateTime.now().microsecondsSinceEpoch}',
+      author: state.currentMember,
+      content: content,
+      createdAt: DateTime.now(),
+    );
+    state = state.copyWith(entries: [...state.entries, entry]);
+  }
+}

--- a/lib/features/community/discussion_detail/provider/discussion_detail_view_model.g.dart
+++ b/lib/features/community/discussion_detail/provider/discussion_detail_view_model.g.dart
@@ -1,0 +1,65 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'discussion_detail_view_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(DiscussionDetailViewModel)
+final discussionDetailViewModelProvider = DiscussionDetailViewModelProvider._();
+
+final class DiscussionDetailViewModelProvider
+    extends
+        $NotifierProvider<DiscussionDetailViewModel, DiscussionDetailState> {
+  DiscussionDetailViewModelProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'discussionDetailViewModelProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$discussionDetailViewModelHash();
+
+  @$internal
+  @override
+  DiscussionDetailViewModel create() => DiscussionDetailViewModel();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DiscussionDetailState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DiscussionDetailState>(value),
+    );
+  }
+}
+
+String _$discussionDetailViewModelHash() =>
+    r'f3a4dd2ee900c64ac0fb494d325802fa5a58d0eb';
+
+abstract class _$DiscussionDetailViewModel
+    extends $Notifier<DiscussionDetailState> {
+  DiscussionDetailState build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<DiscussionDetailState, DiscussionDetailState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<DiscussionDetailState, DiscussionDetailState>,
+              DiscussionDetailState,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/lib/features/community/discussion_detail/view/discussion_detail_view.dart
+++ b/lib/features/community/discussion_detail/view/discussion_detail_view.dart
@@ -52,36 +52,36 @@ final class _DiscussionDetailViewState
         ],
       ),
       body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const EmptyBox.smallHeight(),
-            Padding(
-              padding: const PagePadding.horizontal16Symmetric(),
-              child: GeneralInfoBanner(
-                icon: AppIcons.visibilityOff,
-                message: LocaleKeys
-                    .community_groupDetail_discussions_anonymityBanner
-                    .tr(),
+        child: Padding(
+          padding: const PagePadding.vertical8Symmetric(),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            spacing: WidgetSizes.spacingXs,
+            children: [
+              Padding(
+                padding: const PagePadding.horizontal16Symmetric(),
+                child: GeneralInfoBanner(
+                  icon: AppIcons.visibilityOff,
+                  message: LocaleKeys
+                      .community_groupDetail_discussions_anonymityBanner
+                      .tr(),
+                ),
               ),
-            ),
-            const EmptyBox.smallHeight(),
-            Expanded(
-              child: _EntriesList(
-                state: state,
-                scrollController: entriesScrollController,
+              Expanded(
+                child: _EntriesList(
+                  state: state,
+                  scrollController: entriesScrollController,
+                ),
               ),
-            ),
-            const EmptyBox.smallHeight(),
-            Padding(
-              padding: const PagePadding.horizontal16Symmetric(),
-              child: DiscussionReplyComposer(
-                controller: replyController,
-                onSubmit: submitReply,
+              Padding(
+                padding: const PagePadding.horizontal16Symmetric(),
+                child: DiscussionReplyComposer(
+                  controller: replyController,
+                  onSubmit: submitReply,
+                ),
               ),
-            ),
-            const EmptyBox.smallHeight(),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/community/discussion_detail/view/discussion_detail_view.dart
+++ b/lib/features/community/discussion_detail/view/discussion_detail_view.dart
@@ -1,0 +1,89 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_context_colors.dart';
+import 'package:lifeclient/features/community/discussion_detail/model/discussion_detail_args.dart';
+import 'package:lifeclient/features/community/discussion_detail/provider/discussion_detail_state.dart';
+import 'package:lifeclient/features/community/discussion_detail/provider/discussion_detail_view_model.dart';
+import 'package:lifeclient/features/community/discussion_detail/view/mixin/discussion_detail_view_mixin.dart';
+import 'package:lifeclient/features/community/discussion_detail/view/widget/discussion_entry_tile.dart';
+import 'package:lifeclient/features/community/discussion_detail/view/widget/discussion_reply_composer.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+import 'package:lifeclient/product/utility/constants/app_constants.dart';
+import 'package:lifeclient/product/utility/constants/app_icons.dart';
+import 'package:lifeclient/product/utility/decorations/empty_box.dart';
+import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
+import 'package:lifeclient/product/widget/general/general_not_found_widget.dart';
+import 'package:lifeclient/product/widget/general/index.dart';
+
+part 'sub_view/discussion_entries_list.dart';
+part 'sub_view/discussion_header_title.dart';
+
+final class DiscussionDetailView extends ConsumerStatefulWidget {
+  const DiscussionDetailView({required this.args, super.key});
+
+  final DiscussionDetailArgs args;
+
+  @override
+  ConsumerState<DiscussionDetailView> createState() =>
+      _DiscussionDetailViewState();
+}
+
+final class _DiscussionDetailViewState
+    extends ConsumerState<DiscussionDetailView>
+    with AppProviderMixin<DiscussionDetailView>, DiscussionDetailViewMixin {
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(discussionDetailViewModelProvider);
+    return Scaffold(
+      appBar: AppBar(
+        toolbarHeight: WidgetSizes.spacingXxl9,
+        title: _DiscussionHeaderTitle(args: widget.args),
+        actions: [
+          Padding(
+            padding: const PagePadding.onlyRight(),
+            child: GeneralStatusBadge(
+              label: state.entries.length.toString(),
+              color: context.appColors.navy400,
+              icon: AppIcons.comment,
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const EmptyBox.smallHeight(),
+            Padding(
+              padding: const PagePadding.horizontal16Symmetric(),
+              child: GeneralInfoBanner(
+                icon: AppIcons.visibilityOff,
+                message: LocaleKeys
+                    .community_groupDetail_discussions_anonymityBanner
+                    .tr(),
+              ),
+            ),
+            const EmptyBox.smallHeight(),
+            Expanded(
+              child: _EntriesList(
+                state: state,
+                scrollController: entriesScrollController,
+              ),
+            ),
+            const EmptyBox.smallHeight(),
+            Padding(
+              padding: const PagePadding.horizontal16Symmetric(),
+              child: DiscussionReplyComposer(
+                controller: replyController,
+                onSubmit: submitReply,
+              ),
+            ),
+            const EmptyBox.smallHeight(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/community/discussion_detail/view/mixin/discussion_detail_view_mixin.dart
+++ b/lib/features/community/discussion_detail/view/mixin/discussion_detail_view_mixin.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lifeclient/features/community/discussion_detail/provider/discussion_detail_view_model.dart';
+import 'package:lifeclient/features/community/discussion_detail/view/discussion_detail_view.dart';
+import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
+
+mixin DiscussionDetailViewMixin
+    on
+        ConsumerState<DiscussionDetailView>,
+        AppProviderMixin<DiscussionDetailView> {
+  final TextEditingController replyController = TextEditingController();
+  final ScrollController entriesScrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref
+          .read(discussionDetailViewModelProvider.notifier)
+          .fetchEntries(widget.args.discussion);
+    });
+  }
+
+  @override
+  void dispose() {
+    replyController.dispose();
+    entriesScrollController.dispose();
+    super.dispose();
+  }
+
+  void submitReply() {
+    final content = replyController.text.trim();
+    if (content.isEmpty) return;
+    ref.read(discussionDetailViewModelProvider.notifier).addEntry(content);
+    replyController.clear();
+    _scrollToLatestEntry();
+  }
+
+  // Yeni gönderi listeye eklendikten (frame çizildikten) sonra en alta
+  // kaydırır.
+  void _scrollToLatestEntry() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!entriesScrollController.hasClients) return;
+      entriesScrollController.animateTo(
+        entriesScrollController.position.maxScrollExtent,
+        duration: Durations.medium2,
+        curve: Curves.easeOut,
+      );
+    });
+  }
+}

--- a/lib/features/community/discussion_detail/view/mixin/discussion_detail_view_mixin.dart
+++ b/lib/features/community/discussion_detail/view/mixin/discussion_detail_view_mixin.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lifeclient/features/community/discussion_detail/provider/discussion_detail_view_model.dart';
 import 'package:lifeclient/features/community/discussion_detail/view/discussion_detail_view.dart';
+import 'package:lifeclient/product/utility/extension/string_extension.dart';
 import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
 
 mixin DiscussionDetailViewMixin
@@ -30,15 +31,13 @@ mixin DiscussionDetailViewMixin
   }
 
   void submitReply() {
-    final content = replyController.text.trim();
+    final content = replyController.text.normalize;
     if (content.isEmpty) return;
     ref.read(discussionDetailViewModelProvider.notifier).addEntry(content);
     replyController.clear();
     _scrollToLatestEntry();
   }
 
-  // Yeni gönderi listeye eklendikten (frame çizildikten) sonra en alta
-  // kaydırır.
   void _scrollToLatestEntry() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!entriesScrollController.hasClients) return;

--- a/lib/features/community/discussion_detail/view/sub_view/discussion_entries_list.dart
+++ b/lib/features/community/discussion_detail/view/sub_view/discussion_entries_list.dart
@@ -1,0 +1,28 @@
+part of '../discussion_detail_view.dart';
+
+final class _EntriesList extends StatelessWidget {
+  const _EntriesList({required this.state, required this.scrollController});
+
+  final DiscussionDetailState state;
+  final ScrollController scrollController;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state) {
+      DiscussionDetailState(isFetching: true) => const SizedBox.shrink(),
+      DiscussionDetailState(isError: true) => SingleChildScrollView(
+        child: GeneralNotFoundWidget(
+          title: LocaleKeys.message_somethingWentWrong.tr(),
+        ),
+      ),
+      DiscussionDetailState(:final entries) => ListView.separated(
+        controller: scrollController,
+        padding: const PagePadding.horizontal16Symmetric(),
+        itemCount: entries.length,
+        separatorBuilder: (context, index) => const EmptyBox.smallHeight(),
+        itemBuilder: (context, index) =>
+            DiscussionEntryTile(model: entries[index]),
+      ),
+    };
+  }
+}

--- a/lib/features/community/discussion_detail/view/sub_view/discussion_header_title.dart
+++ b/lib/features/community/discussion_detail/view/sub_view/discussion_header_title.dart
@@ -1,0 +1,29 @@
+part of '../discussion_detail_view.dart';
+
+final class _DiscussionHeaderTitle extends StatelessWidget {
+  const _DiscussionHeaderTitle({required this.args});
+
+  final DiscussionDetailArgs args;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        GeneralContentTitle(
+          value: args.discussion.title,
+          fontWeight: FontWeight.w700,
+          maxLine: AppConstants.kTwo,
+        ),
+        GeneralContentSmallTitle(
+          value: LocaleKeys.community_groupDetail_discussions_openedByGroup.tr(
+            args: [args.discussion.author.maskedDisplayName, args.group.name],
+          ),
+          color: context.appColors.navy300,
+          maxLine: AppConstants.kOne,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/community/discussion_detail/view/widget/discussion_entry_tile.dart
+++ b/lib/features/community/discussion_detail/view/widget/discussion_entry_tile.dart
@@ -1,0 +1,76 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:kartal/kartal.dart';
+import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_context_colors.dart';
+import 'package:lifeclient/features/community/model/group_discussion_entry_model.dart';
+import 'package:lifeclient/features/community/model/group_member_role.dart';
+import 'package:lifeclient/features/community/widget/group_member_avatar.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+import 'package:lifeclient/product/utility/decorations/custom_radius.dart';
+import 'package:lifeclient/product/utility/decorations/empty_box.dart';
+import 'package:lifeclient/product/utility/extension/date_time_extension.dart';
+import 'package:lifeclient/product/widget/general/index.dart';
+
+@immutable
+final class DiscussionEntryTile extends StatelessWidget {
+  const DiscussionEntryTile({required this.model, super.key});
+
+  final GroupDiscussionEntryModel model;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.general.colorScheme;
+    return Card(
+      margin: EdgeInsets.zero,
+      shape: const RoundedRectangleBorder(borderRadius: CustomRadius.large),
+      child: Padding(
+        padding: const PagePadding.generalCardAll(),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                GroupMemberAvatar(
+                  displayName: model.author.displayName,
+                  backgroundColor: context.appColors.ink300,
+                  singleLetter: true,
+                ),
+                const EmptyBox(width: WidgetSizes.spacingS),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          GeneralContentSubTitle(
+                            value: model.author.maskedDisplayName,
+                            fontWeight: FontWeight.w700,
+                          ),
+                          if (model.author.role == GroupMemberRole.admin) ...[
+                            const EmptyBox.smallWidth(),
+                            GeneralStatusBadge(
+                              label: LocaleKeys.community_groupDetail_adminBadge
+                                  .tr(),
+                              color: colorScheme.tertiary,
+                            ),
+                          ],
+                        ],
+                      ),
+                      GeneralContentSmallTitle(
+                        value: model.createdAt.timeAgo,
+                        color: context.appColors.navy300,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const EmptyBox.smallHeight(),
+            GeneralContentSubTitle(value: model.content),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/community/discussion_detail/view/widget/discussion_reply_composer.dart
+++ b/lib/features/community/discussion_detail/view/widget/discussion_reply_composer.dart
@@ -1,0 +1,63 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:kartal/kartal.dart';
+import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/features/community/widget/community_send_button.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+import 'package:lifeclient/product/utility/decorations/custom_radius.dart';
+
+@immutable
+final class DiscussionReplyComposer extends StatelessWidget {
+  const DiscussionReplyComposer({
+    required this.controller,
+    required this.onSubmit,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: context.general.colorScheme.outlineVariant,
+        borderRadius: CustomRadius.xxLarge,
+      ),
+      child: Padding(
+        padding: const PagePadding.horizontalLowVerticalVeryLowSymmetric(),
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: controller,
+                minLines: 1,
+                maxLines: 4,
+                textInputAction: TextInputAction.newline,
+                decoration: InputDecoration(
+                  hintText: LocaleKeys
+                      .community_groupDetail_discussions_replyComposerHint
+                      .tr(),
+                  isCollapsed: true,
+                  filled: false,
+                  border: InputBorder.none,
+                  enabledBorder: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                ),
+              ),
+            ),
+            ValueListenableBuilder<TextEditingValue>(
+              valueListenable: controller,
+              builder: (context, value, _) {
+                final canSubmit = value.text.trim().isNotEmpty;
+                return CommunitySendButton(
+                  onTap: canSubmit ? onSubmit : null,
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/community/group_detail/discussions/view/group_discussions_view.dart
+++ b/lib/features/community/group_detail/discussions/view/group_discussions_view.dart
@@ -9,7 +9,9 @@ import 'package:lifeclient/features/community/group_detail/discussions/provider/
 import 'package:lifeclient/features/community/group_detail/discussions/view/mixin/group_discussions_view_mixin.dart';
 import 'package:lifeclient/features/community/group_detail/discussions/view/widget/group_discussion_tile.dart';
 import 'package:lifeclient/features/community/group_detail/discussions/view/widget/start_discussion_card.dart';
+import 'package:lifeclient/features/community/discussion_detail/model/discussion_detail_args.dart';
 import 'package:lifeclient/features/community/model/group_model.dart';
+import 'package:lifeclient/product/navigation/app_router.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/utility/decorations/empty_box.dart';
 import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
@@ -70,9 +72,12 @@ final class _GroupDiscussionsViewState
                 padding: const PagePadding.vertical6Symmetric(),
                 child: GroupDiscussionTile(
                   model: discussion,
-                  // TODO(community): Tartışma Detay PR'ında
-                  // DiscussionDetailRoute'a bağlanacak.
-                  onTap: () {},
+                  onTap: () => DiscussionDetailRoute(
+                    $extra: DiscussionDetailArgs(
+                      group: widget.model,
+                      discussion: discussion,
+                    ),
+                  ).push<void>(context),
                 ),
               ),
             ),

--- a/lib/features/community/group_detail/discussions/view/mixin/group_discussions_view_mixin.dart
+++ b/lib/features/community/group_detail/discussions/view/mixin/group_discussions_view_mixin.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lifeclient/features/community/group_detail/discussions/provider/group_discussions_view_model.dart';
 import 'package:lifeclient/features/community/group_detail/discussions/view/group_discussions_view.dart';
+import 'package:lifeclient/features/community/discussion_detail/model/discussion_detail_args.dart';
 import 'package:lifeclient/features/community/group_detail/discussions/view/widget/start_discussion_sheet.dart';
+import 'package:lifeclient/product/navigation/app_router.dart';
 import 'package:lifeclient/features/community/provider/current_group_member_provider.dart';
 import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
 
@@ -33,8 +35,10 @@ mixin GroupDiscussionsViewMixin
   }
 
   Future<void> startDiscussion(BuildContext context) async {
-    await StartDiscussionSheet.show(context);
-    // TODO(community): Tartışma Detay PR'ında açılan tartışma
-    // DiscussionDetailRoute'a yönlendirilecek.
+    final discussion = await StartDiscussionSheet.show(context);
+    if (discussion == null || !context.mounted) return;
+    await DiscussionDetailRoute(
+      $extra: DiscussionDetailArgs(group: widget.model, discussion: discussion),
+    ).push<void>(context);
   }
 }

--- a/lib/product/navigation/app_router.dart
+++ b/lib/product/navigation/app_router.dart
@@ -4,6 +4,8 @@ import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/auth/view/login_view.dart';
 import 'package:lifeclient/features/chain_store/view/chain_store_view.dart';
 import 'package:lifeclient/features/community/create_group/view/create_group_view.dart';
+import 'package:lifeclient/features/community/discussion_detail/model/discussion_detail_args.dart';
+import 'package:lifeclient/features/community/discussion_detail/view/discussion_detail_view.dart';
 import 'package:lifeclient/features/community/group_detail/group_detail_view.dart';
 import 'package:lifeclient/features/community/groups/view/groups_view.dart';
 import 'package:lifeclient/features/community/model/group_model.dart';
@@ -420,6 +422,18 @@ final class GroupDetailRoute extends GoRouteData with $GroupDetailRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       GroupDetailView(model: $extra);
+}
+
+@TypedGoRoute<DiscussionDetailRoute>(path: '/discussion-detail')
+final class DiscussionDetailRoute extends GoRouteData
+    with $DiscussionDetailRoute {
+  DiscussionDetailRoute({required this.$extra});
+
+  final DiscussionDetailArgs $extra;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      DiscussionDetailView(args: $extra);
 }
 
 final class OnboardRoute extends GoRouteData with $OnboardRoute {

--- a/lib/product/navigation/app_router.g.dart
+++ b/lib/product/navigation/app_router.g.dart
@@ -13,6 +13,7 @@ List<RouteBase> get $appRoutes => [
   $unauthorizedRoute,
   $groupsRoute,
   $groupDetailRoute,
+  $discussionDetailRoute,
 ];
 
 RouteBase get $splashRoute => GoRouteData.$route(
@@ -795,6 +796,36 @@ mixin $GroupDetailRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/group-detail');
+
+  @override
+  void go(BuildContext context) => context.go(location, extra: _self.$extra);
+
+  @override
+  Future<T?> push<T>(BuildContext context) =>
+      context.push<T>(location, extra: _self.$extra);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location, extra: _self.$extra);
+
+  @override
+  void replace(BuildContext context) =>
+      context.replace(location, extra: _self.$extra);
+}
+
+RouteBase get $discussionDetailRoute => GoRouteData.$route(
+  path: '/discussion-detail',
+  factory: $DiscussionDetailRoute._fromState,
+);
+
+mixin $DiscussionDetailRoute on GoRouteData {
+  static DiscussionDetailRoute _fromState(GoRouterState state) =>
+      DiscussionDetailRoute($extra: state.extra as DiscussionDetailArgs);
+
+  DiscussionDetailRoute get _self => this as DiscussionDetailRoute;
+
+  @override
+  String get location => GoRouteData.$location('/discussion-detail');
 
   @override
   void go(BuildContext context) => context.go(location, extra: _self.$extra);


### PR DESCRIPTION
#375'in bölünmüş hali — 5/5, son parça (#377, #378, #379, #387 üzerine kuruludur).

## Kapsam
- Tartışma Detay ekranı — gönderi akışı, isimler maskeli (`S••• Y•••••`), gizlilik bandı
- Yanıt kutusu (`DiscussionReplyComposer`) — gönderi eklenince liste otomatik en alta kayar
- AppBar'da gönderi sayısını gösteren rozet
- `DiscussionDetailRoute` eklendi; Grup Detay'daki iki bağlantı açıldı:
  - Tartışma kartına tıklama → detay
  - "Tartışma aç" → oluşturunca doğrudan detaya yönlendirme

## Notlar
- Tüm renkler `context.general.colorScheme` / `context.appColors` üzerinden; `AppColors` doğrudan kullanımı yok. `context.appColors`'a `ink300` token'ı eklendi.
- Mock çağrıları TODO ile işaretli; Firestore servis PR'ında gerçek isteğe bağlanacak. Bu PR'da fake `delay` yok — gerçek loading Firestore async'i ile gelecek.
- `fetchEntries` mock senkron olduğu için `void` + tek atama.

## Screenshots

| Tartışma Detay | Yanıt yazma |
|:---:|:---:|
| <img width="250" alt="Tartışma Detay" src="https://github.com/user-attachments/assets/a363804f-c2d4-4ce7-bd64-372dbe0c6324" /> | <img width="250" alt="Yanıt yazma" src="https://github.com/user-attachments/assets/59b546e2-a45f-4c4d-898c-5d07d4e6ed63" /> |

Closes #349