### PR TITLE
feat(community): connect groups list & creation to Firestore

### DIFF
--- a/lib/features/community/create_group/provider/create_group_view_model.dart
+++ b/lib/features/community/create_group/provider/create_group_view_model.dart
@@ -1,8 +1,16 @@
+import 'dart:io';
+
+import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/core/dependency/index.dart';
+import 'package:lifeclient/features/auth/view_model/auth_state.dart';
+import 'package:lifeclient/features/auth/view_model/auth_view_model.dart';
 import 'package:lifeclient/features/community/create_group/model/create_group_model.dart';
 import 'package:lifeclient/features/community/create_group/provider/create_group_state.dart';
+import 'package:lifeclient/features/community/groups/provider/groups_view_model.dart';
 import 'package:lifeclient/features/community/mock/community_mock_data.dart';
+import 'package:lifeclient/features/community/model/group_model.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uuid/uuid.dart';
 
 part 'create_group_view_model.g.dart';
 
@@ -21,11 +29,43 @@ final class CreateGroupViewModel extends _$CreateGroupViewModel
     );
   }
 
-  // TODO(community): Firestore servis PR'ında model gerçek isteğe gönderilecek.
   Future<bool> createGroup(CreateGroupModel model) async {
+    final authState = ref.read(authViewModelProvider);
+    if (authState is! Authenticated) return false;
+
     state = state.copyWith(isSubmitting: true);
-    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    final imageUrl = await _uploadCoverImage(model.coverImageFile);
+    final group = GroupModel(
+      creatorUid: authState.user.uid,
+      name: model.name,
+      description: model.description,
+      imageUrl: imageUrl,
+    );
+    final result = await firestoreService.add<GroupModel>(
+      model: group,
+      path: CollectionPaths.groups,
+    );
+
     state = state.copyWith(isSubmitting: false);
+    if (result.dataOrNull == null) return false;
+
+    await ref.read(groupsViewModelProvider.notifier).fetchGroups();
     return true;
+  }
+
+  Future<String?> _uploadCoverImage(File? file) async {
+    if (file == null) return null;
+    try {
+      final bytes = await file.readAsBytes();
+      final result = await storageService.uploadImage(
+        root: RootStorageName.company,
+        key: const Uuid().v4(),
+        fileBytes: bytes,
+      );
+      return result.dataOrNull;
+    } on Exception {
+      return null;
+    }
   }
 }

--- a/lib/features/community/group_detail/widget/sliver_header/expanded_background.dart
+++ b/lib/features/community/group_detail/widget/sliver_header/expanded_background.dart
@@ -12,7 +12,7 @@ final class _ExpandedBackground extends StatelessWidget {
       background: Stack(
         fit: StackFit.expand,
         children: [
-          GroupCoverImage(groupId: model.id, imageUrl: model.coverImageUrl),
+          GroupCoverImage(groupId: model.id, imageUrl: model.imageUrl),
           DecoratedBox(
             decoration: BoxDecoration(
               gradient: LinearGradient(

--- a/lib/features/community/groups/provider/groups_view_model.dart
+++ b/lib/features/community/groups/provider/groups_view_model.dart
@@ -1,6 +1,7 @@
+import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/core/dependency/index.dart';
 import 'package:lifeclient/features/community/groups/provider/groups_state.dart';
-import 'package:lifeclient/features/community/mock/community_mock_data.dart';
+import 'package:lifeclient/features/community/model/group_model.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'groups_view_model.g.dart';
@@ -13,9 +14,14 @@ final class GroupsViewModel extends _$GroupsViewModel
 
   Future<void> fetchGroups() async {
     state = state.copyWith(isFetching: true, isError: false);
+    final result = await firestoreService.getList<GroupModel>(
+      model: const GroupModel.empty(),
+      path: CollectionPaths.groups,
+    );
     state = state.copyWith(
-      groups: CommunityMockData.groups,
+      groups: result.dataOrNull ?? const [],
       isFetching: false,
+      isError: !result.isSuccess,
     );
   }
 }

--- a/lib/features/community/groups/view/widget/group_card.dart
+++ b/lib/features/community/groups/view/widget/group_card.dart
@@ -66,7 +66,7 @@ final class _CoverImage extends StatelessWidget {
       height: double.infinity,
       child: GroupCoverImage(
         groupId: model.id,
-        imageUrl: model.coverImageUrl,
+        imageUrl: model.imageUrl,
       ),
     );
   }

--- a/lib/features/community/mock/community_mock_data.dart
+++ b/lib/features/community/mock/community_mock_data.dart
@@ -5,7 +5,6 @@ import 'package:lifeclient/features/community/model/group_member_model.dart';
 import 'package:lifeclient/features/community/model/group_member_role.dart';
 import 'package:lifeclient/features/community/model/group_model.dart';
 import 'package:lifeclient/features/community/model/group_post_model.dart';
-import 'package:lifeclient/features/community/model/group_type.dart';
 
 /// Community feature'ının tek mock veri kaynağı.
 // TODO(community): Firestore bağlanınca bu dosya silinecek.
@@ -89,7 +88,7 @@ final class CommunityMockData {
       name: 'Antakya Esnaf Dayanışması',
       description: 'Uzun Çarşı ve çevresi esnafının dayanışma ağı.',
       memberCount: 248,
-      coverImageUrl: 'https://picsum.photos/seed/antakya-esnaf/400',
+      imageUrl: 'https://picsum.photos/seed/antakya-esnaf/400',
       createdAt: DateTime(2025, 1, 12),
       admins: const [saim, ahmet],
     ),
@@ -98,7 +97,7 @@ final class CommunityMockData {
       name: 'Defne Mahalle Komitesi',
       description: 'Defne mahalleleri için yardımlaşma ve iletişim.',
       memberCount: 96,
-      coverImageUrl: 'https://picsum.photos/seed/defne-mahalle/400',
+      imageUrl: 'https://picsum.photos/seed/defne-mahalle/400',
       createdAt: DateTime(2025, 2, 3),
       admins: const [zeynep],
     ),
@@ -115,7 +114,7 @@ final class CommunityMockData {
       name: 'Samandağ Gönüllüleri',
       description: 'Bölge için gönüllülük ve yardımlaşma çalışmaları.',
       memberCount: 131,
-      coverImageUrl: 'https://picsum.photos/seed/samandag/400',
+      imageUrl: 'https://picsum.photos/seed/samandag/400',
       createdAt: DateTime(2025, 3, 8),
       admins: const [deniz, currentMember],
     ),
@@ -124,7 +123,7 @@ final class CommunityMockData {
       name: 'Harbiye Üreticileri',
       description: 'Yerel üreticiler arası kapalı iletişim ve sipariş ağı.',
       memberCount: 57,
-      type: GroupType.closed,
+      isClosed: true,
       createdAt: DateTime(2025, 4, 15),
       admins: const [hasan],
     ),

--- a/lib/features/community/model/group_model.dart
+++ b/lib/features/community/model/group_model.dart
@@ -1,60 +1,99 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/community/model/group_member_model.dart';
 import 'package:lifeclient/features/community/model/group_type.dart';
 
-final class GroupModel extends Equatable {
+part 'group_model.g.dart';
+
+@JsonSerializable(includeIfNull: false)
+final class GroupModel extends BaseFirebaseModel<GroupModel>
+    with EquatableMixin {
   const GroupModel({
-    required this.id,
-    required this.name,
-    required this.description,
-    required this.memberCount,
-    this.coverImageUrl,
-    this.type = GroupType.open,
+    this.id = '',
+    this.creatorUid = '',
+    this.name = '',
+    this.description = '',
+    this.imageUrl,
+    this.isClosed = false,
+    this.memberCount = 0,
     this.createdAt,
     this.admins = const [],
   });
 
+  const GroupModel.empty() : this();
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
   final String id;
+  final String creatorUid;
   final String name;
   final String description;
+  final String? imageUrl;
+  final bool isClosed;
+  @JsonKey(includeFromJson: false, includeToJson: false)
   final int memberCount;
-  final String? coverImageUrl;
-  final GroupType type;
+  @JsonKey(
+    includeToJson: false,
+    fromJson: FirebaseTimeParse.datetimeFromTimestamp,
+  )
   final DateTime? createdAt;
+  @JsonKey(includeFromJson: false, includeToJson: false)
   final List<GroupMemberModel> admins;
 
-  /// Verilen üyenin bu grubun yöneticisi olup olmadığı.
-  bool isAdmin(String memberId) => admins.any((admin) => admin.id == memberId);
+  GroupType get type => isClosed ? GroupType.closed : GroupType.open;
+
+  bool isAdmin(String memberId) =>
+      memberId == creatorUid || admins.any((admin) => admin.id == memberId);
+
+  @override
+  String get documentId => id;
+
+  @override
+  Map<String, dynamic> toJson() => _$GroupModelToJson(this);
+
+  @override
+  GroupModel fromJson(Map<String, dynamic> json) => _$GroupModelFromJson(json);
+
+  @override
+  GroupModel fromFirebase(DocumentSnapshot<Map<String, dynamic>> snapshot) {
+    final data = snapshot.data();
+    if (data == null) return const GroupModel.empty();
+    return fromJson(data).copyWith(id: snapshot.id);
+  }
 
   @override
   List<Object?> get props => [
     id,
+    creatorUid,
     name,
     description,
+    imageUrl,
+    isClosed,
     memberCount,
-    coverImageUrl,
-    type,
     createdAt,
     admins,
   ];
 
   GroupModel copyWith({
     String? id,
+    String? creatorUid,
     String? name,
     String? description,
+    String? imageUrl,
+    bool? isClosed,
     int? memberCount,
-    String? coverImageUrl,
-    GroupType? type,
     DateTime? createdAt,
     List<GroupMemberModel>? admins,
   }) {
     return GroupModel(
       id: id ?? this.id,
+      creatorUid: creatorUid ?? this.creatorUid,
       name: name ?? this.name,
       description: description ?? this.description,
+      imageUrl: imageUrl ?? this.imageUrl,
+      isClosed: isClosed ?? this.isClosed,
       memberCount: memberCount ?? this.memberCount,
-      coverImageUrl: coverImageUrl ?? this.coverImageUrl,
-      type: type ?? this.type,
       createdAt: createdAt ?? this.createdAt,
       admins: admins ?? this.admins,
     );


### PR DESCRIPTION
## Özet
Community grupları mock'tan Firestore'a taşındı: liste okuma + grup oluşturma (kapak görseli Storage'a) gerçek bağlantıya geçti. #349

## Değişiklikler
- `GroupModel` → `BaseFirebaseModel` (toJson/fromJson, rules alan adları: creatorUid/imageUrl/isClosed)
- Grup listesi `firestoreService.getList` ile `/groups`'tan okuyor
- Grup oluşturma `firestoreService.add` + kapak `storageService`'e yükleniyor
- Debug'da Storage emülatörü bağlandı (useStorageEmulator)

## Ertelendi (ekip kararı)
- Kategori Firestore bağlantısı, açık/kapalı toggle, `groups` storage kökü (life_shared), members/üye sayısı

## Test
- Emülatörde liste okuma, grup oluşturma + kapak yükleme, yetki (claim) doğrulandı
