### PR TITLE
chore(deps): life_shared feat/group-category + riverpod/flutter_gen codegen refresh

### DIFF
--- a/lib/features/auth/view_model/auth_view_model.g.dart
+++ b/lib/features/auth/view_model/auth_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$AuthViewModel extends $Notifier<AuthState> {
   AuthState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AuthState, AuthState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$AuthViewModel extends $Notifier<AuthState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/chain_store/provider/chain_store_provider.g.dart
+++ b/lib/features/chain_store/provider/chain_store_provider.g.dart
@@ -48,7 +48,7 @@ abstract class _$ChainStoreProvider extends $Notifier<ChainStoreState> {
   ChainStoreState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<ChainStoreState, ChainStoreState>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$ChainStoreProvider extends $Notifier<ChainStoreState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/details/provider/event_detail_provider.g.dart
+++ b/lib/features/details/provider/event_detail_provider.g.dart
@@ -48,7 +48,7 @@ abstract class _$EventDetailProvider extends $Notifier<EventDetailState> {
   EventDetailState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<EventDetailState, EventDetailState>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$EventDetailProvider extends $Notifier<EventDetailState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/main/event/provider/event_view_model.g.dart
+++ b/lib/features/main/event/provider/event_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$EventViewModel extends $Notifier<EventState> {
   EventState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<EventState, EventState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$EventViewModel extends $Notifier<EventState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/main/history/provider/history_view_model.g.dart
+++ b/lib/features/main/history/provider/history_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$HistoryViewModel extends $Notifier<HistoryState> {
   HistoryState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<HistoryState, HistoryState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$HistoryViewModel extends $Notifier<HistoryState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/main/home/provider/home_view_model.g.dart
+++ b/lib/features/main/home/provider/home_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$HomeViewModel extends $Notifier<HomeState> {
   HomeState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<HomeState, HomeState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$HomeViewModel extends $Notifier<HomeState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/main/news_jobs/provider/news_jobs_provider.g.dart
+++ b/lib/features/main/news_jobs/provider/news_jobs_provider.g.dart
@@ -47,7 +47,7 @@ abstract class _$NewsJobsProvider extends $Notifier<NewsJobsState> {
   NewsJobsState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<NewsJobsState, NewsJobsState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$NewsJobsProvider extends $Notifier<NewsJobsState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/sub_feature/developers/provider/developers_view_model.g.dart
+++ b/lib/features/sub_feature/developers/provider/developers_view_model.g.dart
@@ -48,7 +48,7 @@ abstract class _$DevelopersViewModel extends $Notifier<DevelopersState> {
   DevelopersState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<DevelopersState, DevelopersState>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$DevelopersViewModel extends $Notifier<DevelopersState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/sub_feature/favorite/provider/favorite_view_model.g.dart
+++ b/lib/features/sub_feature/favorite/provider/favorite_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$FavoriteViewModel extends $Notifier<FavoriteState> {
   FavoriteState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<FavoriteState, FavoriteState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$FavoriteViewModel extends $Notifier<FavoriteState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/sub_feature/filter_and_search/provider/filter_search_provider.g.dart
+++ b/lib/features/sub_feature/filter_and_search/provider/filter_search_provider.g.dart
@@ -47,7 +47,7 @@ abstract class _$FilterWithSearch extends $Notifier<FilterSearchState> {
   FilterSearchState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<FilterSearchState, FilterSearchState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$FilterWithSearch extends $Notifier<FilterSearchState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/sub_feature/forms/place_request/provider/place_request_provider.g.dart
+++ b/lib/features/sub_feature/forms/place_request/provider/place_request_provider.g.dart
@@ -48,7 +48,7 @@ abstract class _$PlaceRequestProvider extends $Notifier<PlaceRequestState> {
   PlaceRequestState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<PlaceRequestState, PlaceRequestState>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$PlaceRequestProvider extends $Notifier<PlaceRequestState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/sub_feature/forms/project_request/provider/project_request_provider.g.dart
+++ b/lib/features/sub_feature/forms/project_request/provider/project_request_provider.g.dart
@@ -48,7 +48,7 @@ abstract class _$ProjectRequestProvider extends $Notifier<ProjectRequestState> {
   ProjectRequestState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<ProjectRequestState, ProjectRequestState>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$ProjectRequestProvider extends $Notifier<ProjectRequestState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/sub_feature/forms/scholarship_request/provider/scholarship_request_provider.g.dart
+++ b/lib/features/sub_feature/forms/scholarship_request/provider/scholarship_request_provider.g.dart
@@ -51,7 +51,7 @@ abstract class _$ScholarshipRequestProvider
   ScholarshipRequestState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<ScholarshipRequestState, ScholarshipRequestState>;
     final element =
@@ -62,6 +62,6 @@ abstract class _$ScholarshipRequestProvider
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/sub_feature/special_agency/provider/special_agency_view_model.g.dart
+++ b/lib/features/sub_feature/special_agency/provider/special_agency_view_model.g.dart
@@ -48,7 +48,7 @@ abstract class _$SpecialAgencyViewModel extends $Notifier<SpecialAgencyState> {
   SpecialAgencyState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<SpecialAgencyState, SpecialAgencyState>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$SpecialAgencyViewModel extends $Notifier<SpecialAgencyState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/sub_feature/useful_links/provider/useful_links_view_model.g.dart
+++ b/lib/features/sub_feature/useful_links/provider/useful_links_view_model.g.dart
@@ -48,7 +48,7 @@ abstract class _$UsefulLinksViewModel extends $Notifier<UsefulLinksState> {
   UsefulLinksState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<UsefulLinksState, UsefulLinksState>;
     final element =
         ref.element
@@ -58,6 +58,6 @@ abstract class _$UsefulLinksViewModel extends $Notifier<UsefulLinksState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/tourism/provider/tourism_view_model.g.dart
+++ b/lib/features/tourism/provider/tourism_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$TourismViewModel extends $Notifier<TourismState> {
   TourismState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<TourismState, TourismState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$TourismViewModel extends $Notifier<TourismState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/product/generated/assets.gen.dart
+++ b/lib/product/generated/assets.gen.dart
@@ -129,7 +129,9 @@ class $AssetsTranslationsGen {
   List<String> get values => [en, tr];
 }
 
-abstract final class Assets {
+class Assets {
+  const Assets._();
+
   static const $AssetsDocsGen docs = $AssetsDocsGen();
   static const $AssetsIconsGen icons = $AssetsIconsGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();

--- a/lib/product/generated/fonts.gen.dart
+++ b/lib/product/generated/fonts.gen.dart
@@ -8,7 +8,9 @@
 // ignore_for_file: type=lint
 // ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-abstract final class FontFamily {
+class FontFamily {
+  FontFamily._();
+
   /// Font family: DMSerifDisplay
   static const String dMSerifDisplay = 'DMSerifDisplay';
 

--- a/lib/sub_feature/advertisement_board/provider/advertisement_board_view_model.g.dart
+++ b/lib/sub_feature/advertisement_board/provider/advertisement_board_view_model.g.dart
@@ -54,7 +54,7 @@ abstract class _$AdvertisementBoardViewModel
   AdvertisementBoardState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AdvertisementBoardState, AdvertisementBoardState>;
     final element =
@@ -65,6 +65,6 @@ abstract class _$AdvertisementBoardViewModel
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/sub_feature/main_tab/view_model/main_tab_view_model.g.dart
+++ b/lib/sub_feature/main_tab/view_model/main_tab_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$MainTabViewModel extends $Notifier<MainTabState> {
   MainTabState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<MainTabState, MainTabState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$MainTabViewModel extends $Notifier<MainTabState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -102,7 +102,7 @@ dependencies:
   life_shared:
     git:
       url: https://github.com/VB-CORE/life_shared.git
-      ref: v5.4.17
+      ref: feat/group-category
 
   file_picker: ^10.3.8
   sliver_tools: ^0.2.12


### PR DESCRIPTION
## Özet
- `life_shared` git ref'i `v5.4.17` → `feat/group-category` (grup alt-koleksiyon path'leri + `RootStorageName.groups` için gerekli)
- Yeni riverpod codegen imzası (`WhenComplete runBuild()`) — takipli tüm `*_view_model.g.dart` / `*_provider.g.dart` yeniden üretildi
- flutter_gen codegen güncellemesi (`assets.gen.dart`, `fonts.gen.dart`)

Not: Bu PR salt altyapı/codegen tazeleme — mantık değişikliği yok. Community feature'ları bunun üstüne gelir.

## Test Edildi
- `flutter analyze` = 0 hata

İlgili: #349
