### PR TITLE
refactor(community): grup modellerini Firestore yapısına taşı

### DIFF
--- a/lib/features/community/discussion_detail/view/widget/discussion_entry_tile.dart
+++ b/lib/features/community/discussion_detail/view/widget/discussion_entry_tile.dart
@@ -58,7 +58,7 @@ final class DiscussionEntryTile extends StatelessWidget {
                         ],
                       ),
                       GeneralContentSmallTitle(
-                        value: model.createdAt.timeAgo,
+                        value: (model.createdAt ?? DateTime.now()).timeAgo,
                         color: context.appColors.navy300,
                       ),
                     ],

--- a/lib/features/community/group_detail/discussions/view/widget/group_discussion_tile.dart
+++ b/lib/features/community/group_detail/discussions/view/widget/group_discussion_tile.dart
@@ -58,7 +58,7 @@ final class GroupDiscussionTile extends StatelessWidget {
                           .tr(
                             args: [
                               model.author.maskedDisplayName,
-                              model.createdAt.timeAgo,
+                              (model.createdAt ?? DateTime.now()).timeAgo,
                               model.entryCount.toString(),
                             ],
                           ),

--- a/lib/features/community/group_detail/wall/view/widget/group_post_card.dart
+++ b/lib/features/community/group_detail/wall/view/widget/group_post_card.dart
@@ -115,7 +115,7 @@ final class _PostAuthorRow extends StatelessWidget {
               fontWeight: FontWeight.w700,
             ),
             GeneralContentSmallTitle(
-              value: model.createdAt.timeAgo,
+              value: (model.createdAt ?? DateTime.now()).timeAgo,
               color: context.appColors.navy300,
             ),
           ],

--- a/lib/features/community/model/group_discussion_entry_model.dart
+++ b/lib/features/community/model/group_discussion_entry_model.dart
@@ -1,19 +1,72 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
+import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/community/model/group_member_model.dart';
 
-final class GroupDiscussionEntryModel extends Equatable {
+final class GroupDiscussionEntryModel
+    extends BaseFirebaseModel<GroupDiscussionEntryModel>
+    with EquatableMixin {
   const GroupDiscussionEntryModel({
-    required this.id,
-    required this.author,
-    required this.content,
-    required this.createdAt,
+    this.id = '',
+    this.author = const GroupMemberModel.empty(),
+    this.content = '',
+    this.createdAt,
+    this.isDeleted = false,
   });
+
+  const GroupDiscussionEntryModel.empty() : this();
 
   final String id;
   final GroupMemberModel author;
   final String content;
-  final DateTime createdAt;
+  final DateTime? createdAt;
+  final bool isDeleted;
 
   @override
-  List<Object> get props => [id, author, content, createdAt];
+  String get documentId => id;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...author.toAuthorJson(),
+    'content': content,
+    'isDeleted': isDeleted,
+    'createdAt': FieldValue.serverTimestamp(),
+  };
+
+  @override
+  GroupDiscussionEntryModel fromJson(Map<String, dynamic> json) =>
+      GroupDiscussionEntryModel(
+        author: GroupMemberModel.authorFromJson(json),
+        content: (json['content'] as String?) ?? '',
+        createdAt: FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
+        isDeleted: (json['isDeleted'] as bool?) ?? false,
+      );
+
+  @override
+  GroupDiscussionEntryModel fromFirebase(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+  ) {
+    final data = snapshot.data();
+    if (data == null) return const GroupDiscussionEntryModel.empty();
+    return fromJson(data).copyWith(id: snapshot.id);
+  }
+
+  @override
+  List<Object?> get props => [id, author, content, createdAt, isDeleted];
+
+  GroupDiscussionEntryModel copyWith({
+    String? id,
+    GroupMemberModel? author,
+    String? content,
+    DateTime? createdAt,
+    bool? isDeleted,
+  }) {
+    return GroupDiscussionEntryModel(
+      id: id ?? this.id,
+      author: author ?? this.author,
+      content: content ?? this.content,
+      createdAt: createdAt ?? this.createdAt,
+      isDeleted: isDeleted ?? this.isDeleted,
+    );
+  }
 }

--- a/lib/features/community/model/group_discussion_model.dart
+++ b/lib/features/community/model/group_discussion_model.dart
@@ -1,33 +1,82 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
+import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/community/model/group_discussion_entry_model.dart';
 import 'package:lifeclient/features/community/model/group_member_model.dart';
 
-final class GroupDiscussionModel extends Equatable {
+final class GroupDiscussionModel extends BaseFirebaseModel<GroupDiscussionModel>
+    with EquatableMixin {
   const GroupDiscussionModel({
-    required this.id,
-    required this.title,
-    required this.author,
-    required this.createdAt,
+    this.id = '',
+    this.title = '',
+    this.author = const GroupMemberModel.empty(),
+    this.createdAt,
+    this.isDeleted = false,
+    this.entryCount = 0,
     this.entries = const [],
   });
+
+  const GroupDiscussionModel.empty() : this();
 
   final String id;
   final String title;
   final GroupMemberModel author;
-  final DateTime createdAt;
+  final DateTime? createdAt;
+  final bool isDeleted;
 
+  final int entryCount;
+
+  // Geçici geriye-uyumluluk: eski UI discussion.entries okuyor. UI Firestore'a
+  // taşınınca (entryCount + entries alt-koleksiyonu) bu alan kaldırılacak.
   final List<GroupDiscussionEntryModel> entries;
 
-  int get entryCount => entries.length;
+  @override
+  String get documentId => id;
 
   @override
-  List<Object> get props => [id, title, author, createdAt, entries];
+  Map<String, dynamic> toJson() => {
+    'title': title,
+    ...author.toAuthorJson(),
+    'isDeleted': isDeleted,
+    'createdAt': FieldValue.serverTimestamp(),
+  };
+
+  @override
+  GroupDiscussionModel fromJson(Map<String, dynamic> json) =>
+      GroupDiscussionModel(
+        title: (json['title'] as String?) ?? '',
+        author: GroupMemberModel.authorFromJson(json),
+        createdAt: FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
+        isDeleted: (json['isDeleted'] as bool?) ?? false,
+      );
+
+  @override
+  GroupDiscussionModel fromFirebase(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+  ) {
+    final data = snapshot.data();
+    if (data == null) return const GroupDiscussionModel.empty();
+    return fromJson(data).copyWith(id: snapshot.id);
+  }
+
+  @override
+  List<Object?> get props => [
+    id,
+    title,
+    author,
+    createdAt,
+    isDeleted,
+    entryCount,
+    entries,
+  ];
 
   GroupDiscussionModel copyWith({
     String? id,
     String? title,
     GroupMemberModel? author,
     DateTime? createdAt,
+    bool? isDeleted,
+    int? entryCount,
     List<GroupDiscussionEntryModel>? entries,
   }) {
     return GroupDiscussionModel(
@@ -35,6 +84,8 @@ final class GroupDiscussionModel extends Equatable {
       title: title ?? this.title,
       author: author ?? this.author,
       createdAt: createdAt ?? this.createdAt,
+      isDeleted: isDeleted ?? this.isDeleted,
+      entryCount: entryCount ?? this.entryCount,
       entries: entries ?? this.entries,
     );
   }

--- a/lib/features/community/model/group_member_model.dart
+++ b/lib/features/community/model/group_member_model.dart
@@ -1,16 +1,26 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/community/model/group_member_role.dart';
 import 'package:lifeclient/product/model/auth/user_model.dart';
 import 'package:lifeclient/product/utility/constants/regex_types.dart';
 
-final class GroupMemberModel extends Equatable {
+part 'group_member_model.g.dart';
+
+@JsonSerializable(includeIfNull: false)
+final class GroupMemberModel extends BaseFirebaseModel<GroupMemberModel>
+    with EquatableMixin {
   const GroupMemberModel({
-    required this.id,
-    required this.displayName,
-    required this.username,
+    this.id = '',
+    this.displayName = '',
+    this.username = '',
     this.avatarUrl,
     this.role = GroupMemberRole.member,
+    this.isDeleted = false,
   });
+
+  const GroupMemberModel.empty() : this();
 
   factory GroupMemberModel.fromUser(UserModel user) {
     return GroupMemberModel(
@@ -21,13 +31,14 @@ final class GroupMemberModel extends Equatable {
     );
   }
 
+  @JsonKey(includeFromJson: false, includeToJson: false)
   final String id;
   final String displayName;
   final String username;
   final String? avatarUrl;
   final GroupMemberRole role;
+  final bool isDeleted;
 
-  /// Tartışmalar sekmesi için isim maskesi — "Saim Yıldırım" → "S••• Y•••••".
   String get maskedDisplayName {
     return displayName
         .trim()
@@ -40,8 +51,51 @@ final class GroupMemberModel extends Equatable {
         .join(' ');
   }
 
+  Map<String, dynamic> toAuthorJson() => {
+    'authorUid': id,
+    'authorDisplayName': displayName,
+    'authorUsername': username,
+    if (avatarUrl != null) 'authorAvatarUrl': avatarUrl,
+    'authorRole': role.name,
+  };
+
+  static GroupMemberModel authorFromJson(Map<String, dynamic> json) =>
+      GroupMemberModel(
+        id: (json['authorUid'] as String?) ?? '',
+        displayName: (json['authorDisplayName'] as String?) ?? '',
+        username: (json['authorUsername'] as String?) ?? '',
+        avatarUrl: json['authorAvatarUrl'] as String?,
+        role: GroupMemberRole.fromString(json['authorRole'] as String?),
+      );
+
   @override
-  List<Object?> get props => [id, displayName, username, avatarUrl, role];
+  String get documentId => id;
+
+  @override
+  Map<String, dynamic> toJson() => _$GroupMemberModelToJson(this);
+
+  @override
+  GroupMemberModel fromJson(Map<String, dynamic> json) =>
+      _$GroupMemberModelFromJson(json);
+
+  @override
+  GroupMemberModel fromFirebase(
+    DocumentSnapshot<Map<String, dynamic>> snapshot,
+  ) {
+    final data = snapshot.data();
+    if (data == null) return const GroupMemberModel.empty();
+    return fromJson(data).copyWith(id: snapshot.id);
+  }
+
+  @override
+  List<Object?> get props => [
+    id,
+    displayName,
+    username,
+    avatarUrl,
+    role,
+    isDeleted,
+  ];
 
   GroupMemberModel copyWith({
     String? id,
@@ -49,6 +103,7 @@ final class GroupMemberModel extends Equatable {
     String? username,
     String? avatarUrl,
     GroupMemberRole? role,
+    bool? isDeleted,
   }) {
     return GroupMemberModel(
       id: id ?? this.id,
@@ -56,6 +111,7 @@ final class GroupMemberModel extends Equatable {
       username: username ?? this.username,
       avatarUrl: avatarUrl ?? this.avatarUrl,
       role: role ?? this.role,
+      isDeleted: isDeleted ?? this.isDeleted,
     );
   }
 }

--- a/lib/features/community/model/group_model.dart
+++ b/lib/features/community/model/group_model.dart
@@ -17,6 +17,7 @@ final class GroupModel extends BaseFirebaseModel<GroupModel>
     this.description = '',
     this.imageUrl,
     this.isClosed = false,
+    this.isDeleted = false,
     this.memberCount = 0,
     this.createdAt,
     this.admins = const [],
@@ -31,6 +32,7 @@ final class GroupModel extends BaseFirebaseModel<GroupModel>
   final String description;
   final String? imageUrl;
   final bool isClosed;
+  final bool isDeleted;
   @JsonKey(includeFromJson: false, includeToJson: false)
   final int memberCount;
   @JsonKey(
@@ -50,7 +52,10 @@ final class GroupModel extends BaseFirebaseModel<GroupModel>
   String get documentId => id;
 
   @override
-  Map<String, dynamic> toJson() => _$GroupModelToJson(this);
+  Map<String, dynamic> toJson() => {
+    ..._$GroupModelToJson(this),
+    'createdAt': FieldValue.serverTimestamp(),
+  };
 
   @override
   GroupModel fromJson(Map<String, dynamic> json) => _$GroupModelFromJson(json);
@@ -70,6 +75,7 @@ final class GroupModel extends BaseFirebaseModel<GroupModel>
     description,
     imageUrl,
     isClosed,
+    isDeleted,
     memberCount,
     createdAt,
     admins,
@@ -82,6 +88,7 @@ final class GroupModel extends BaseFirebaseModel<GroupModel>
     String? description,
     String? imageUrl,
     bool? isClosed,
+    bool? isDeleted,
     int? memberCount,
     DateTime? createdAt,
     List<GroupMemberModel>? admins,
@@ -93,6 +100,7 @@ final class GroupModel extends BaseFirebaseModel<GroupModel>
       description: description ?? this.description,
       imageUrl: imageUrl ?? this.imageUrl,
       isClosed: isClosed ?? this.isClosed,
+      isDeleted: isDeleted ?? this.isDeleted,
       memberCount: memberCount ?? this.memberCount,
       createdAt: createdAt ?? this.createdAt,
       admins: admins ?? this.admins,

--- a/lib/features/community/model/group_post_model.dart
+++ b/lib/features/community/model/group_post_model.dart
@@ -1,29 +1,68 @@
 import 'dart:io';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
+import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/community/model/group_member_model.dart';
 
-final class GroupPostModel extends Equatable {
+final class GroupPostModel extends BaseFirebaseModel<GroupPostModel>
+    with EquatableMixin {
   const GroupPostModel({
-    required this.id,
-    required this.author,
-    required this.content,
-    required this.createdAt,
+    this.id = '',
+    this.author = const GroupMemberModel.empty(),
+    this.content = '',
+    this.createdAt,
     this.imageUrl,
     this.imageFile,
     this.likeCount = 0,
     this.commentCount = 0,
+    this.isDeleted = false,
   });
+
+  const GroupPostModel.empty() : this();
 
   final String id;
   final GroupMemberModel author;
   final String content;
-  final DateTime createdAt;
+  final DateTime? createdAt;
   final String? imageUrl;
 
   final File? imageFile;
   final int likeCount;
   final int commentCount;
+  final bool isDeleted;
+
+  @override
+  String get documentId => id;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    ...author.toAuthorJson(),
+    'content': content,
+    if (imageUrl != null) 'imageUrl': imageUrl,
+    'likeCount': likeCount,
+    'commentCount': commentCount,
+    'isDeleted': isDeleted,
+    'createdAt': FieldValue.serverTimestamp(),
+  };
+
+  @override
+  GroupPostModel fromJson(Map<String, dynamic> json) => GroupPostModel(
+    author: GroupMemberModel.authorFromJson(json),
+    content: (json['content'] as String?) ?? '',
+    imageUrl: json['imageUrl'] as String?,
+    createdAt: FirebaseTimeParse.datetimeFromTimestamp(json['createdAt']),
+    likeCount: (json['likeCount'] as num?)?.toInt() ?? 0,
+    commentCount: (json['commentCount'] as num?)?.toInt() ?? 0,
+    isDeleted: (json['isDeleted'] as bool?) ?? false,
+  );
+
+  @override
+  GroupPostModel fromFirebase(DocumentSnapshot<Map<String, dynamic>> snapshot) {
+    final data = snapshot.data();
+    if (data == null) return const GroupPostModel.empty();
+    return fromJson(data).copyWith(id: snapshot.id);
+  }
 
   @override
   List<Object?> get props => [
@@ -35,6 +74,7 @@ final class GroupPostModel extends Equatable {
     imageFile,
     likeCount,
     commentCount,
+    isDeleted,
   ];
 
   GroupPostModel copyWith({
@@ -46,6 +86,7 @@ final class GroupPostModel extends Equatable {
     File? imageFile,
     int? likeCount,
     int? commentCount,
+    bool? isDeleted,
   }) {
     return GroupPostModel(
       id: id ?? this.id,
@@ -56,6 +97,7 @@ final class GroupPostModel extends Equatable {
       imageFile: imageFile ?? this.imageFile,
       likeCount: likeCount ?? this.likeCount,
       commentCount: commentCount ?? this.commentCount,
+      isDeleted: isDeleted ?? this.isDeleted,
     );
   }
 }


### PR DESCRIPTION
## Özet
- Grup modelleri (group, post, member, discussion, entry) `BaseFirebaseModel` yapısına taşındı
- Author denormalizasyonu (`toAuthorJson`) + isim maskesi (`maskedDisplayName`)

## Durum
- #349 migrasyonunun **katman 1/4'ü** (modeller)
- Tek başına `upstream/main` üstünde derlenir
- Geçici geriye-uyumluluk: `GroupDiscussionModel.entries` shim + tile'larda `createdAt` null-safe erişim → UI katmanı taşınınca (PR 4) kaldırılacak

## Sıra (her merge yeşil)
`PR1 model → PR2 servis → PR3 UI-liste → PR4 UI-detay`

İlgili: #349