### PR TITLE
fix(community): grup olusturunca sekme sifirlanmasi ve FAB duzeltmesi

### DIFF
--- a/lib/features/community/create_group/view/mixin/create_group_view_mixin.dart
+++ b/lib/features/community/create_group/view/mixin/create_group_view_mixin.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/community/create_group/model/create_group_model.dart';
 import 'package:lifeclient/features/community/create_group/provider/create_group_view_model.dart';
 import 'package:lifeclient/features/community/create_group/view/create_group_view.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
-import 'package:lifeclient/product/navigation/app_router.dart';
 import 'package:lifeclient/product/package/photo_picker/photo_picker_manager.dart';
 import 'package:lifeclient/product/utility/constants/app_constants.dart';
 import 'package:lifeclient/product/utility/extension/file_size_extension.dart';
@@ -109,8 +109,8 @@ mixin CreateGroupViewMixin
     appProvider.showSnackbarMessage(
       LocaleKeys.community_createGroup_success.tr(),
     );
-    const MainTabRoute().go(context);
+    context.pop();
   }
 
-  void closeView() => const MainTabRoute().go(context);
+  void closeView() => context.pop();
 }

--- a/lib/features/community/discussion_detail/view/mixin/discussion_detail_view_mixin.dart
+++ b/lib/features/community/discussion_detail/view/mixin/discussion_detail_view_mixin.dart
@@ -37,12 +37,12 @@ mixin DiscussionDetailViewMixin
     if (!mounted) return;
 
     if (!isAdded) {
-      replyController.clear();
       appProvider.showSnackbarMessage(
         LocaleKeys.message_somethingWentWrong.tr(),
       );
       return;
     }
+    replyController.clear();
     _scrollToLatestEntry();
   }
 

--- a/lib/features/community/groups/view/groups_view.dart
+++ b/lib/features/community/groups/view/groups_view.dart
@@ -20,6 +20,7 @@ import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
 import 'package:lifeclient/product/widget/general/index.dart';
 import 'package:lifeclient/product/widget/list_view/index.dart';
 
+part 'widget/create_group_fab.dart';
 part 'widget/groups_category_filter.dart';
 part 'widget/groups_list.dart';
 part 'widget/groups_permission_banner.dart';
@@ -36,15 +37,7 @@ final class _GroupsViewState extends ConsumerState<GroupsView>
   @override
   Widget build(BuildContext context) {
     return GeneralScaffold(
-      floatingActionButton: canCreateGroup
-          ? Padding(
-              padding: const EdgeInsets.only(bottom: WidgetSizes.spacingXxl12),
-              child: FloatingActionButton(
-                onPressed: () => const CreateGroupRoute().go(context),
-                child: const Icon(AppIcons.add),
-              ),
-            )
-          : null,
+      floatingActionButton: canCreateGroup ? const _CreateGroupFab() : null,
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/community/groups/view/groups_view.dart
+++ b/lib/features/community/groups/view/groups_view.dart
@@ -13,6 +13,8 @@ import 'package:lifeclient/features/community/groups/view/widget/group_card.dart
 import 'package:lifeclient/features/community/model/group_model.dart';
 import 'package:lifeclient/features/community/provider/group_categories_view_model.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+import 'package:lifeclient/product/navigation/app_router.dart';
+import 'package:lifeclient/product/utility/constants/app_icons.dart';
 import 'package:lifeclient/product/utility/decorations/empty_box.dart';
 import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
 import 'package:lifeclient/product/widget/general/index.dart';
@@ -34,6 +36,15 @@ final class _GroupsViewState extends ConsumerState<GroupsView>
   @override
   Widget build(BuildContext context) {
     return GeneralScaffold(
+      floatingActionButton: canCreateGroup
+          ? Padding(
+              padding: const EdgeInsets.only(bottom: WidgetSizes.spacingXxl12),
+              child: FloatingActionButton(
+                onPressed: () => const CreateGroupRoute().go(context),
+                child: const Icon(AppIcons.add),
+              ),
+            )
+          : null,
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/community/groups/view/mixin/groups_view_mixin.dart
+++ b/lib/features/community/groups/view/mixin/groups_view_mixin.dart
@@ -13,6 +13,10 @@ import 'package:lifeclient/product/widget/dialog/login_required_dialog.dart';
 
 mixin GroupsViewMixin
     on ConsumerState<GroupsView>, AppProviderMixin<GroupsView> {
+  bool get canCreateGroup => ref.watch(
+    authViewModelProvider.select((state) => state.user?.canCreateGroup ?? false),
+  );
+
   Future<void> onGroupTap(GroupModel model) async {
     if (!ref.read(authViewModelProvider).isAuthenticated) {
       return LoginRequiredDialog.show(context);

--- a/lib/features/community/groups/view/widget/create_group_fab.dart
+++ b/lib/features/community/groups/view/widget/create_group_fab.dart
@@ -1,0 +1,17 @@
+part of '../groups_view.dart';
+
+@immutable
+final class _CreateGroupFab extends StatelessWidget {
+  const _CreateGroupFab();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: WidgetSizes.spacingXxl12),
+      child: FloatingActionButton(
+        onPressed: () => const CreateGroupRoute().go(context),
+        child: const Icon(AppIcons.add),
+      ),
+    );
+  }
+}

--- a/lib/product/navigation/app_router.dart
+++ b/lib/product/navigation/app_router.dart
@@ -7,7 +7,6 @@ import 'package:lifeclient/features/community/create_group/view/create_group_vie
 import 'package:lifeclient/features/community/discussion_detail/model/discussion_detail_args.dart';
 import 'package:lifeclient/features/community/discussion_detail/view/discussion_detail_view.dart';
 import 'package:lifeclient/features/community/group_detail/group_detail_view.dart';
-import 'package:lifeclient/features/community/groups/view/groups_view.dart';
 import 'package:lifeclient/features/community/model/group_model.dart';
 import 'package:lifeclient/features/details/view/event_detail_view.dart';
 import 'package:lifeclient/features/details/view/news_detail_view.dart';
@@ -76,6 +75,9 @@ final class SplashRoute extends GoRouteData with $SplashRoute {
     // Settings
     SettingsRoute.route,
     EditProfileRoute.route,
+
+    // Community
+    CreateGroupRoute.route,
   ],
 )
 final class MainTabRoute extends GoRouteData with $MainTabRoute {
@@ -386,21 +388,10 @@ final class UnauthorizedRoute extends GoRouteData with $UnauthorizedRoute {
       UnauthorizedView(attemptedPath: attemptedPath);
 }
 
-@TypedGoRoute<GroupsRoute>(
-  path: '/groups',
-  routes: [
-    TypedGoRoute<CreateGroupRoute>(path: 'create-group'),
-  ],
-)
-final class GroupsRoute extends GoRouteData with $GroupsRoute {
-  const GroupsRoute();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) => const GroupsView();
-}
-
 final class CreateGroupRoute extends GoRouteData with $CreateGroupRoute {
   const CreateGroupRoute();
+
+  static const route = TypedGoRoute<CreateGroupRoute>(path: 'create-group');
 
   @override
   String? redirect(BuildContext context, GoRouterState state) =>

--- a/lib/product/navigation/app_router.g.dart
+++ b/lib/product/navigation/app_router.g.dart
@@ -11,7 +11,6 @@ List<RouteBase> get $appRoutes => [
   $mainTabRoute,
   $loginRoute,
   $unauthorizedRoute,
-  $groupsRoute,
   $groupDetailRoute,
   $discussionDetailRoute,
 ];
@@ -214,6 +213,11 @@ RouteBase get $mainTabRoute => GoRouteData.$route(
       name: 'Edit Profile',
       hasOverriddenOnExit: false,
       factory: $EditProfileRoute._fromState,
+    ),
+    GoRouteData.$route(
+      path: 'create-group',
+      hasOverriddenOnExit: false,
+      factory: $CreateGroupRoute._fromState,
     ),
   ],
 );
@@ -719,6 +723,27 @@ mixin $EditProfileRoute on GoRouteData {
   void replace(BuildContext context) => context.replace(location);
 }
 
+mixin $CreateGroupRoute on GoRouteData {
+  static CreateGroupRoute _fromState(GoRouterState state) =>
+      const CreateGroupRoute();
+
+  @override
+  String get location => GoRouteData.$location('/main/create-group');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
 RouteBase get $loginRoute => GoRouteData.$route(
   path: '/login',
   hasOverriddenOnExit: false,
@@ -771,60 +796,6 @@ mixin $UnauthorizedRoute on GoRouteData {
       if (_self.attemptedPath != null) 'attempted-path': _self.attemptedPath,
     },
   );
-
-  @override
-  void go(BuildContext context) => context.go(location);
-
-  @override
-  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
-
-  @override
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
-
-  @override
-  void replace(BuildContext context) => context.replace(location);
-}
-
-RouteBase get $groupsRoute => GoRouteData.$route(
-  path: '/groups',
-  hasOverriddenOnExit: false,
-  factory: $GroupsRoute._fromState,
-  routes: [
-    GoRouteData.$route(
-      path: 'create-group',
-      hasOverriddenOnExit: false,
-      factory: $CreateGroupRoute._fromState,
-    ),
-  ],
-);
-
-mixin $GroupsRoute on GoRouteData {
-  static GroupsRoute _fromState(GoRouterState state) => const GroupsRoute();
-
-  @override
-  String get location => GoRouteData.$location('/groups');
-
-  @override
-  void go(BuildContext context) => context.go(location);
-
-  @override
-  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
-
-  @override
-  void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
-
-  @override
-  void replace(BuildContext context) => context.replace(location);
-}
-
-mixin $CreateGroupRoute on GoRouteData {
-  static CreateGroupRoute _fromState(GoRouterState state) =>
-      const CreateGroupRoute();
-
-  @override
-  String get location => GoRouteData.$location('/groups/create-group');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/lib/sub_feature/main_tab/main_tab_view.dart
+++ b/lib/sub_feature/main_tab/main_tab_view.dart
@@ -9,8 +9,6 @@ import 'package:lifeclient/core/theme/app_radius.dart';
 import 'package:lifeclient/core/theme/app_shadows.dart';
 import 'package:lifeclient/core/theme/app_spacing.dart';
 import 'package:lifeclient/core/theme/app_text.dart';
-import 'package:lifeclient/features/auth/view_model/auth_state.dart';
-import 'package:lifeclient/features/auth/view_model/auth_view_model.dart';
 import 'package:lifeclient/product/generated/assets.gen.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/navigation/app_router.dart';

--- a/lib/sub_feature/main_tab/model/speed_dial_child_model.dart
+++ b/lib/sub_feature/main_tab/model/speed_dial_child_model.dart
@@ -18,25 +18,15 @@ final class SpeedDialChildModel {
 }
 
 final class SpeedDialChildModelList {
-  SpeedDialChildModelList({
-    required BuildContext context,
-    this.canCreateGroup = false,
-  }) {
+  SpeedDialChildModelList({required BuildContext context}) {
     _context = context;
     _fillItems(_context);
   }
-
-  final bool canCreateGroup;
 
   late BuildContext _context;
 
   void _fillItems(BuildContext context) {
     _speedDialChildItems = [
-      SpeedDialChildModel(
-        location: const CreateGroupRoute().location,
-        title: LocaleKeys.community_createGroup_title.tr(context: context),
-        isVisible: canCreateGroup,
-      ),
       SpeedDialChildModel(
         location: const PlaceRequestFormRoute().location,
         title: LocaleKeys.requestCompany_title.tr(context: context),

--- a/lib/sub_feature/main_tab/widget/main_fab_button.dart
+++ b/lib/sub_feature/main_tab/widget/main_fab_button.dart
@@ -5,15 +5,7 @@ final class _SpeedDialFabWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final canCreateGroup = ref.watch(
-      authViewModelProvider.select(
-        (state) => state.user?.canCreateGroup ?? false,
-      ),
-    );
-    final items = SpeedDialChildModelList(
-      context: context,
-      canCreateGroup: canCreateGroup,
-    ).speedDialChildItems;
+    final items = SpeedDialChildModelList(context: context).speedDialChildItems;
     return CustomSpeedDial(
       children: items
           .map(


### PR DESCRIPTION
## Summary
- Grup olusturunca hem bottom nav (Mekanlar/Akis/Kesfet/Profil) hem ic sekmenin (Haberler/Etkinlikler/Gruplar) sifirlanmasi duzeltildi: `CreateGroupRoute` artik `MainTabRoute` altinda nested (onceden ayri `/groups` dali altindaydi), boylece MainTabView instance'i koruyor; basari/iptal durumunda `MainTabRoute().go()` yerine `context.pop()` kullaniliyor.
- "Grup Olustur" global FAB'dan (speed dial) kaldirildi, GroupsView'in kendi FAB'i eklendi (yalnizca `canCreateGroup` yetkisi olanlara gorunur).
- Discussion (tartisma) cevap kutusu: mesaj basariyla gonderilince artik temizleniyor (onceden tam tersiydi - sadece hata durumunda temizleniyordu).

## Test plan
- [x] Emulator'da grup olusturma akisi test edildi - Gruplar sekmesinde kalindigi ve bottom nav/ic sekme durumunun sifirlanmadigi dogrulandi
- [x] Global speed dial FAB'da "Grup Olustur" secenegi olmadigi, GroupsView'da yetkili kullanicilar icin FAB gorundugu dogrulandi
- [x] Discussion reply textfield'inin basarili gonderim sonrasi temizlendigi dogrulandi
