### PR TITLE
feat(main-tab): keşfet menüsünü kart tasarımına çevir

### DIFF
--- a/lib/core/theme/app_context_colors.dart
+++ b/lib/core/theme/app_context_colors.dart
@@ -12,6 +12,7 @@ extension AppContextColors on BuildContext {
 final class AppColorTokens {
   const AppColorTokens();
 
+  Color get navy => AppColors.navy;
   Color get navy100 => AppColors.navy100;
   Color get navy300 => AppColors.navy300;
   Color get navy400 => AppColors.navy400;
@@ -27,7 +28,9 @@ final class AppColorTokens {
   Color get gold => AppColors.gold;
   Color get gold200 => AppColors.gold200;
   Color get gold300 => AppColors.gold300;
+  Color get coral => AppColors.coral;
   Color get coral100 => AppColors.coral100;
+  Color get teal => AppColors.teal;
 
   /// `colorScheme.surface`'tan farklıdır (o `AppColors.bg`'ye eşlenir);
   /// bu, `AppColors.surface`'ın (düz beyaz) kendisidir.

--- a/lib/product/utility/constants/app_icons.dart
+++ b/lib/product/utility/constants/app_icons.dart
@@ -63,6 +63,8 @@ final class AppIcons {
   static const IconData hourglassFilled = Icons.hourglass_bottom_rounded;
   static const IconData store = Icons.storefront_outlined;
   static const IconData storeFilled = Icons.storefront_rounded;
+  static const IconData accountBalance = Icons.account_balance_outlined;
+  static const IconData link = Icons.link_rounded;
   static const IconData rate = Icons.stars_rounded;
   static const IconData privacy = Icons.shield_outlined;
   static const IconData privacyFilled = Icons.shield_rounded;

--- a/lib/sub_feature/main_tab/main_tab_view.dart
+++ b/lib/sub_feature/main_tab/main_tab_view.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show ImageFilter;
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -5,15 +7,18 @@ import 'package:kartal/kartal.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/core/dependency/project_dependency_items.dart';
 import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/core/theme/app_context_colors.dart';
 import 'package:lifeclient/core/theme/app_radius.dart';
 import 'package:lifeclient/core/theme/app_shadows.dart';
 import 'package:lifeclient/core/theme/app_spacing.dart';
 import 'package:lifeclient/core/theme/app_text.dart';
+import 'package:lifeclient/features/community/widget/soft_icon_box.dart';
 import 'package:lifeclient/product/generated/assets.gen.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/navigation/app_router.dart';
 import 'package:lifeclient/product/utility/constants/app_constants.dart';
 import 'package:lifeclient/product/utility/constants/app_icons.dart';
+import 'package:lifeclient/product/utility/decorations/empty_box.dart';
 import 'package:lifeclient/product/utility/mixin/index.dart';
 import 'package:lifeclient/product/widget/general/semantics/general_semantic.dart';
 import 'package:lifeclient/product/widget/general/semantics/general_semantic_keys.dart';
@@ -26,6 +31,7 @@ import 'package:lifeclient/sub_feature/main_tab/model/speed_dial_child_model.dar
 import 'package:lifeclient/sub_feature/main_tab/model/tab_model.dart';
 import 'package:lifeclient/sub_feature/main_tab/view_model/main_tab_view_model.dart';
 
+part 'widget/discover_menu_overlay.dart';
 part 'widget/main_app_bar.dart';
 part 'widget/main_bottom_app_bar.dart';
 part 'widget/main_fab_button.dart';

--- a/lib/sub_feature/main_tab/widget/discover_menu_overlay.dart
+++ b/lib/sub_feature/main_tab/widget/discover_menu_overlay.dart
@@ -8,9 +8,10 @@ final class _DiscoverMenuOverlay {
     final topInset = MediaQuery.paddingOf(context).top + appBarHeight;
     return showGeneralDialog<void>(
       context: context,
+      barrierDismissible: true,
       barrierLabel: LocaleKeys.navigationTabs_explore.tr(),
-      barrierColor: Colors.transparent,
-      pageBuilder: (context, animation, secondaryAnimation) {
+      barrierColor: context.appColors.navy.withValues(alpha: 0.05),
+      transitionBuilder: (context, animation, secondaryAnimation, child) {
         return Stack(
           children: [
             Positioned(
@@ -18,19 +19,21 @@ final class _DiscoverMenuOverlay {
               left: kZero,
               right: kZero,
               bottom: kZero,
-              child: GestureDetector(
-                onTap: () => Navigator.of(context).pop(),
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(
-                    sigmaX: WidgetSizes.spacingXs,
-                    sigmaY: WidgetSizes.spacingXs,
-                  ),
-                  child: Container(
-                    color: context.appColors.navy.withValues(alpha: 0.05),
-                  ),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(
+                  sigmaX: WidgetSizes.spacingXs,
+                  sigmaY: WidgetSizes.spacingXs,
                 ),
+                child: const SizedBox.expand(),
               ),
             ),
+            child,
+          ],
+        );
+      },
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return Stack(
+          children: [
             Positioned(
               top: topInset,
               left: AppSpacing.lg,

--- a/lib/sub_feature/main_tab/widget/discover_menu_overlay.dart
+++ b/lib/sub_feature/main_tab/widget/discover_menu_overlay.dart
@@ -8,7 +8,6 @@ final class _DiscoverMenuOverlay {
     final topInset = MediaQuery.paddingOf(context).top + appBarHeight;
     return showGeneralDialog<void>(
       context: context,
-      barrierDismissible: true,
       barrierLabel: LocaleKeys.navigationTabs_explore.tr(),
       barrierColor: Colors.transparent,
       pageBuilder: (context, animation, secondaryAnimation) {
@@ -19,13 +18,16 @@ final class _DiscoverMenuOverlay {
               left: kZero,
               right: kZero,
               bottom: kZero,
-              child: BackdropFilter(
-                filter: ImageFilter.blur(
-                  sigmaX: WidgetSizes.spacingXs,
-                  sigmaY: WidgetSizes.spacingXs,
-                ),
-                child: Container(
-                  color: context.appColors.navy.withValues(alpha: 0.05),
+              child: GestureDetector(
+                onTap: () => Navigator.of(context).pop(),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(
+                    sigmaX: WidgetSizes.spacingXs,
+                    sigmaY: WidgetSizes.spacingXs,
+                  ),
+                  child: Container(
+                    color: context.appColors.navy.withValues(alpha: 0.05),
+                  ),
                 ),
               ),
             ),

--- a/lib/sub_feature/main_tab/widget/discover_menu_overlay.dart
+++ b/lib/sub_feature/main_tab/widget/discover_menu_overlay.dart
@@ -1,0 +1,181 @@
+part of '../main_tab_view.dart';
+
+final class _DiscoverMenuOverlay {
+  const _DiscoverMenuOverlay._();
+
+  static Future<void> show(BuildContext context) {
+    final appBarHeight = Scaffold.of(context).appBarMaxHeight ?? kToolbarHeight;
+    final topInset = MediaQuery.paddingOf(context).top + appBarHeight;
+    return showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: LocaleKeys.navigationTabs_explore.tr(),
+      barrierColor: Colors.transparent,
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return Stack(
+          children: [
+            Positioned(
+              top: topInset,
+              left: kZero,
+              right: kZero,
+              bottom: kZero,
+              child: BackdropFilter(
+                filter: ImageFilter.blur(
+                  sigmaX: WidgetSizes.spacingXs,
+                  sigmaY: WidgetSizes.spacingXs,
+                ),
+                child: Container(
+                  color: context.appColors.navy.withValues(alpha: 0.05),
+                ),
+              ),
+            ),
+            Positioned(
+              top: topInset,
+              left: AppSpacing.lg,
+              right: AppSpacing.lg,
+              child: const _DiscoverMenuCard(),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+final class _DiscoverMenuCard extends StatelessWidget {
+  const _DiscoverMenuCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: context.appColors.surface,
+      elevation: WidgetSizes.spacingXs,
+      shadowColor: context.appColors.navy.withValues(alpha: 0.2),
+      borderRadius: BorderRadius.circular(AppRadius.xl),
+      child: Padding(
+        padding: const PagePadding.generalAllLow(),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const _DiscoverMenuHeader(),
+            const EmptyBox.smallHeight(),
+            _DiscoverMenuItem(
+              icon: AppIcons.accountBalance,
+              iconBackgroundColor: context.appColors.navy,
+              itemLabel: LocaleKeys.specialAgency_title,
+              destination: () {
+                const SpecialAgencyRoute().go(context);
+              },
+            ),
+            _DiscoverMenuItem(
+              icon: AppIcons.store,
+              iconBackgroundColor: context.appColors.coral,
+              itemLabel: LocaleKeys.chain_stores_title,
+              destination: () {
+                const ChainStoresRoute().go(context);
+              },
+            ),
+            _DiscoverMenuItem(
+              icon: AppIcons.camera,
+              iconBackgroundColor: context.appColors.teal,
+              itemLabel: LocaleKeys.tourismView_title,
+              destination: () {
+                const TurismRoute().go(context);
+              },
+            ),
+            _DiscoverMenuItem(
+              icon: AppIcons.link,
+              iconBackgroundColor: context.appColors.olive,
+              itemLabel: LocaleKeys.usefulLink_title,
+              destination: () {
+                const UsefulLinksRoute().go(context);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+final class _DiscoverMenuHeader extends StatelessWidget {
+  const _DiscoverMenuHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Assets.icons.icAppTransparent.image(
+          height: WidgetSizes.spacingXl,
+          width: WidgetSizes.spacingXl,
+        ),
+        const EmptyBox(width: WidgetSizes.spacingS),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              GeneralContentSubTitle(
+                value: LocaleKeys.project_name.tr(),
+                fontWeight: FontWeight.w700,
+              ),
+              Text(
+                LocaleKeys.navigationTabs_explore.tr().toUpperCase(),
+                style: AppText.eyebrow,
+              ),
+            ],
+          ),
+        ),
+        IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: Icon(AppIcons.close, color: context.appColors.ink300),
+        ),
+      ],
+    );
+  }
+}
+
+final class _DiscoverMenuItem extends StatelessWidget {
+  const _DiscoverMenuItem({
+    required this.icon,
+    required this.iconBackgroundColor,
+    required this.itemLabel,
+    required this.destination,
+  });
+
+  final IconData icon;
+  final Color iconBackgroundColor;
+  final String itemLabel;
+  final VoidCallback destination;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(AppRadius.md),
+      onTap: () {
+        Navigator.of(context).pop();
+        destination();
+      },
+      child: Padding(
+        padding: const PagePadding.generalAllLow(),
+        child: Row(
+          children: [
+            SoftIconBox(
+              icon: icon,
+              iconColor: context.appColors.surface,
+              backgroundColor: iconBackgroundColor,
+              backgroundOpacity: 1,
+            ),
+            const EmptyBox(width: WidgetSizes.spacingS),
+            Expanded(
+              child: GeneralContentSubTitle(
+                value: itemLabel.tr(),
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Icon(AppIcons.rightSelect, color: context.appColors.ink300),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/sub_feature/main_tab/widget/discover_menu_overlay.dart
+++ b/lib/sub_feature/main_tab/widget/discover_menu_overlay.dart
@@ -12,35 +12,26 @@ final class _DiscoverMenuOverlay {
       barrierLabel: LocaleKeys.navigationTabs_explore.tr(),
       barrierColor: context.appColors.navy.withValues(alpha: 0.05),
       transitionBuilder: (context, animation, secondaryAnimation, child) {
-        return Stack(
-          children: [
-            Positioned(
-              top: topInset,
-              left: kZero,
-              right: kZero,
-              bottom: kZero,
-              child: BackdropFilter(
-                filter: ImageFilter.blur(
-                  sigmaX: WidgetSizes.spacingXs,
-                  sigmaY: WidgetSizes.spacingXs,
-                ),
-                child: const SizedBox.expand(),
+        return Padding(
+          padding: EdgeInsets.only(top: topInset),
+          child: ClipRect(
+            child: BackdropFilter(
+              filter: ImageFilter.blur(
+                sigmaX: WidgetSizes.spacingXs,
+                sigmaY: WidgetSizes.spacingXs,
               ),
+              child: child,
             ),
-            child,
-          ],
+          ),
         );
       },
       pageBuilder: (context, animation, secondaryAnimation) {
-        return Stack(
-          children: [
-            Positioned(
-              top: topInset,
-              left: AppSpacing.lg,
-              right: AppSpacing.lg,
-              child: const _DiscoverMenuCard(),
-            ),
-          ],
+        return const Padding(
+          padding: EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: _DiscoverMenuCard(),
+          ),
         );
       },
     );

--- a/lib/sub_feature/main_tab/widget/main_app_bar.dart
+++ b/lib/sub_feature/main_tab/widget/main_app_bar.dart
@@ -115,54 +115,12 @@ final class _CustomPopupMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PopupMenuButton(
-      elevation: 0,
+    return IconButton(
+      onPressed: () => _DiscoverMenuOverlay.show(context),
       icon: Icon(
         AppIcons.moreDots,
         color: context.general.colorScheme.primary,
       ),
-      onSelected: (value) {},
-      itemBuilder: (context) {
-        return [
-          _CustomPopupMenuItem<void>(
-            itemLabel: LocaleKeys.specialAgency_title,
-            destination: () {
-              const SpecialAgencyRoute().go(context);
-            },
-          ),
-          _CustomPopupMenuItem<void>(
-            itemLabel: LocaleKeys.chain_stores_title,
-            destination: () {
-              const ChainStoresRoute().go(context);
-            },
-          ),
-          _CustomPopupMenuItem<void>(
-            itemLabel: LocaleKeys.tourismView_title,
-            destination: () {
-              const TurismRoute().go(context);
-            },
-          ),
-          _CustomPopupMenuItem<void>(
-            itemLabel: LocaleKeys.usefulLink_title,
-            destination: () {
-              const UsefulLinksRoute().go(context);
-            },
-          ),
-        ];
-      },
     );
   }
-}
-
-final class _CustomPopupMenuItem<T> extends PopupMenuItem<T> {
-  _CustomPopupMenuItem({
-    required String itemLabel,
-    required VoidCallback destination,
-  }) : super(
-         child: GeneralContentSubTitle(
-           value: itemLabel.tr(),
-           fontWeight: FontWeight.bold,
-         ),
-         onTap: destination,
-       );
 }


### PR DESCRIPTION
## Özet
- App bar'daki "..." menüsü düz liste yerine ikonlu kart tasarımına çevrildi
- Menü artık app bar'ın hemen altında açılıyor, arka planda blur efekti var
- Discover menu widget'ları ayrı dosyaya (`discover_menu_overlay.dart`) taşındı
- `AppContextColors`'a eksik `navy`/`coral`/`teal` renkleri eklendi
- `AppIcons`'a `accountBalance`/`link` ikonları eklendi

## Ekran Görüntüsü
<img width="300" height="649" alt="Simulator Screenshot - iPhone 13 - 2026-07-28 at 12 12 24" src="https://github.com/user-attachments/assets/04e5e885-880a-4844-91e2-285795b22d2a" />

## Test Edildi
- `flutter analyze` temiz