### PR TITLE
feat(settings): redesign SettingsView with flat section-header layout

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -99,6 +99,7 @@
     "title": "Settings",
     "languageTitle": "Language",
     "currentLanguage": "Current language",
+    "appearanceTitle": "Appearance",
     "themeTitle": "{} Theme",
     "developersTitle": "Developers",
     "inactiveDevelopers": "We would like to thank our friends who supported us yesterday ❤️ ",

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -99,6 +99,7 @@
     "title": "Ayarlar",
     "languageTitle": "Dil",
     "currentLanguage": "Mevcut dil",
+    "appearanceTitle": "Görünüm",
     "themeTitle": "{} Tema",
     "developersTitle": "Geliştiriciler",
     "inactiveDevelopers": "Dün bizimle olup destek olan arkadaşlarımıza çok teşekkür ediyoruz ❤️ ",

--- a/lib/core/theme/app_context_colors.dart
+++ b/lib/core/theme/app_context_colors.dart
@@ -29,7 +29,9 @@ final class AppColorTokens {
   Color get gold200 => AppColors.gold200;
   Color get gold300 => AppColors.gold300;
   Color get coral => AppColors.coral;
+  Color get coral50 => AppColors.coral50;
   Color get coral100 => AppColors.coral100;
+  Color get coral500 => AppColors.coral500;
   Color get teal50 => AppColors.teal50;
   Color get teal300 => AppColors.teal300;
   Color get white => AppColors.white;

--- a/lib/features/main/settings/view/settings_view.dart
+++ b/lib/features/main/settings/view/settings_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:kartal/kartal.dart';
 import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
 import 'package:lifeclient/features/main/settings/model/contact_model.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/package/image/custom_network_image.dart';
@@ -12,8 +13,8 @@ import 'package:lifeclient/product/utility/decorations/empty_box.dart';
 import 'package:lifeclient/product/utility/decorations/index.dart';
 import 'package:lifeclient/product/utility/mixin/index.dart';
 import 'package:lifeclient/product/widget/checkbox/notification_permission_checkbox.dart';
-import 'package:lifeclient/product/widget/dropdown/language_dropdown_widget.dart';
 import 'package:lifeclient/product/widget/general/index.dart';
+import 'package:lifeclient/product/widget/list_view/general_group_section_header.dart';
 
 part 'widget/change_language_widget.dart';
 part 'widget/change_notification_widget.dart';
@@ -25,7 +26,7 @@ final class SettingsView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GeneralScaffold(
+    return Scaffold(
       appBar: AppBar(
         title: GeneralSubTitle(
           value: LocaleKeys.settings_title.tr(context: context),

--- a/lib/features/main/settings/view/widget/change_language_widget.dart
+++ b/lib/features/main/settings/view/widget/change_language_widget.dart
@@ -25,7 +25,6 @@ final class _ChangeLanguageWidget extends StatelessWidget {
                 LocaleKeys.settings_currentLanguage.tr(context: context),
               ),
               GeneralSegmentedControl<String>(
-                key: ValueKey(context.locale.languageCode),
                 value: context.locale.languageCode,
                 options: context.supportedLocales
                     .map((locale) => locale.languageCode)

--- a/lib/features/main/settings/view/widget/change_language_widget.dart
+++ b/lib/features/main/settings/view/widget/change_language_widget.dart
@@ -6,23 +6,45 @@ final class _ChangeLanguageWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GeneralExpansionTile(
-      pageTitle: LocaleKeys.settings_languageTitle.tr(),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        GeneralGroupSectionHeader(
+          label: LocaleKeys.settings_languageTitle
+              .tr(context: context)
+              .toUpperCase(),
+        ),
         Padding(
-          padding: const PagePadding.horizontalLowSymmetric(),
+          padding:
+              const PagePadding.horizontalNormalSymmetric() +
+              const PagePadding.vertical12Symmetric(),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               GeneralBodyTitle(
                 LocaleKeys.settings_currentLanguage.tr(context: context),
               ),
-              const IntrinsicWidth(child: LanguageDropdownWidget()),
+              GeneralSegmentedControl<String>(
+                key: ValueKey(context.locale.languageCode),
+                value: context.locale.languageCode,
+                options: context.supportedLocales
+                    .map((locale) => locale.languageCode)
+                    .toList(),
+                labelBuilder: (code) => code.toUpperCase(),
+                onChanged: (code) => _onLanguageChanged(context, code),
+              ),
             ],
           ),
         ),
-        const EmptyBox.middleHeight(),
       ],
     );
+  }
+
+  Future<void> _onLanguageChanged(BuildContext context, String code) async {
+    final index = context.supportedLocales.ext.indexOrNull(
+      (locale) => locale.languageCode == code,
+    );
+    if (index == null) return;
+    await context.setLocale(context.supportedLocales[index]);
   }
 }

--- a/lib/features/main/settings/view/widget/change_notification_widget.dart
+++ b/lib/features/main/settings/view/widget/change_notification_widget.dart
@@ -6,14 +6,15 @@ final class _ChangeNotificationWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GeneralExpansionTile(
-      key: ValueKey(context.locale),
-      pageTitle: LocaleKeys.settings_notificationTitle.tr(),
-      children: const [
-        Padding(
-          padding: PagePadding.horizontalLowSymmetric(),
-          child: NotificationPermissionView(),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        GeneralGroupSectionHeader(
+          label: LocaleKeys.settings_notificationTitle
+              .tr(context: context)
+              .toUpperCase(),
         ),
+        const NotificationPermissionView(),
       ],
     );
   }

--- a/lib/features/main/settings/view/widget/change_theme_widget.dart
+++ b/lib/features/main/settings/view/widget/change_theme_widget.dart
@@ -9,12 +9,14 @@ final class _ChangeThemeWidget extends ConsumerWidget
   Widget build(BuildContext context, WidgetRef ref) {
     final currentTheme = appStateWatch(ref).theme;
 
-    return GeneralExpansionTile(
-      pageTitle: LocaleKeys.settings_themeTitle.tr(
-        args: [_themeLabel(currentTheme).tr(context: context)],
-        context: context,
-      ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        GeneralGroupSectionHeader(
+          label: LocaleKeys.settings_appearanceTitle
+              .tr(context: context)
+              .toUpperCase(),
+        ),
         RadioGroup<ThemeMode>(
           groupValue: currentTheme,
           onChanged: (value) async {

--- a/lib/features/main/settings/view/widget/contact_us_widget.dart
+++ b/lib/features/main/settings/view/widget/contact_us_widget.dart
@@ -15,7 +15,7 @@ final class _ContactUsWidget extends StatelessWidget {
               .tr(context: context)
               .toUpperCase(),
         ),
-        _ContactUsGridView(key: ValueKey(context.locale)),
+        const _ContactUsGridView(),
       ],
     );
   }
@@ -23,7 +23,7 @@ final class _ContactUsWidget extends StatelessWidget {
 
 @immutable
 final class _ContactUsGridView extends StatelessWidget {
-  const _ContactUsGridView({super.key});
+  const _ContactUsGridView();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/main/settings/view/widget/contact_us_widget.dart
+++ b/lib/features/main/settings/view/widget/contact_us_widget.dart
@@ -6,11 +6,16 @@ final class _ContactUsWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GeneralExpansionTile(
-      key: ValueKey(context.locale),
-      pageTitle: LocaleKeys.settings_contactTitle.tr(),
-      children: const [
-        _ContactUsGridView(),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      spacing: AppSpacing.sm,
+      children: [
+        GeneralGroupSectionHeader(
+          label: LocaleKeys.settings_contactTitle
+              .tr(context: context)
+              .toUpperCase(),
+        ),
+        _ContactUsGridView(key: ValueKey(context.locale)),
       ],
     );
   }
@@ -18,12 +23,12 @@ final class _ContactUsWidget extends StatelessWidget {
 
 @immutable
 final class _ContactUsGridView extends StatelessWidget {
-  const _ContactUsGridView();
+  const _ContactUsGridView({super.key});
 
   @override
   Widget build(BuildContext context) {
     return GridView.builder(
-      padding: const PagePadding.onlyBottom(),
+      padding: const PagePadding.horizontalNormalSymmetric(),
       physics: const NeverScrollableScrollPhysics(),
       shrinkWrap: true,
       itemCount: ContactModel.dummyModels.length,
@@ -36,6 +41,8 @@ final class _ContactUsGridView extends StatelessWidget {
   SliverGridDelegateWithFixedCrossAxisCount get _delegate =>
       const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
+        crossAxisSpacing: AppSpacing.sm,
+        mainAxisSpacing: AppSpacing.sm,
         mainAxisExtent: WidgetSizes.spacingXxlL13,
       );
 }
@@ -48,8 +55,9 @@ final class _ContactUsCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       color: Colors.transparent,
-      shape: context.border.roundedRectangleAllBorderNormal
-          .copyWith(side: CustomBorderSides.maxThick),
+      shape: context.border.roundedRectangleAllBorderNormal.copyWith(
+        side: CustomBorderSides.maxThick,
+      ),
       elevation: 0,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/product/init/language/locale_keys.g.dart
+++ b/lib/product/init/language/locale_keys.g.dart
@@ -93,6 +93,7 @@ abstract class  LocaleKeys {
   static const settings_title = 'settings.title';
   static const settings_languageTitle = 'settings.languageTitle';
   static const settings_currentLanguage = 'settings.currentLanguage';
+  static const settings_appearanceTitle = 'settings.appearanceTitle';
   static const settings_themeTitle = 'settings.themeTitle';
   static const settings_developersTitle = 'settings.developersTitle';
   static const settings_inactiveDevelopers = 'settings.inactiveDevelopers';

--- a/lib/product/widget/checkbox/notification_permission_checkbox.dart
+++ b/lib/product/widget/checkbox/notification_permission_checkbox.dart
@@ -1,11 +1,12 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';
 import 'package:lifeclient/product/model/enum/approve_dialog_type.dart';
 import 'package:lifeclient/product/package/settings/custom_app_settings.dart';
+import 'package:lifeclient/product/utility/constants/app_icons.dart';
 import 'package:lifeclient/product/widget/dialog/approve_dialog.dart';
-import 'package:lifeclient/product/widget/general/title/general_body_title.dart';
+import 'package:lifeclient/product/widget/general/general_switch_tile.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 @immutable
 final class NotificationPermissionView extends StatefulWidget {
@@ -16,11 +17,35 @@ final class NotificationPermissionView extends StatefulWidget {
 }
 
 final class _NotificationPermissionViewState
-    extends State<NotificationPermissionView> with _NotificationPermission {
+    extends State<NotificationPermissionView>
+    with WidgetsBindingObserver, _NotificationPermission {
+  late Future<PermissionStatus> _statusFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _statusFuture = Permission.notification.status;
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    setState(() {
+      _statusFuture = Permission.notification.status;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<PermissionStatus>(
-      future: Permission.notification.status,
+      future: _statusFuture,
       builder:
           (BuildContext context, AsyncSnapshot<PermissionStatus> snapshot) {
         final isGranted = snapshot.data == PermissionStatus.granted ||
@@ -33,15 +58,13 @@ final class _NotificationPermissionViewState
           child: AnimatedOpacity(
             duration: Durations.medium2,
             opacity: isGranted ? 0.3 : 1,
-            child: CheckboxListTile(
-              contentPadding: EdgeInsets.zero,
-              value: isGranted,
-              onChanged: (value) {
-                _controlCheckBox(value: value ?? false);
-              },
-              title: GeneralBodyTitle(
-                LocaleKeys.settings_notificationSetting.tr(context: context),
+            child: GeneralSwitchTile(
+              icon: AppIcons.notifications,
+              label: LocaleKeys.settings_notificationSetting.tr(
+                context: context,
               ),
+              value: isGranted,
+              onChanged: (value) => _controlCheckBox(value: value),
             ),
           ),
         );

--- a/lib/product/widget/general/general_segmented_control.dart
+++ b/lib/product/widget/general/general_segmented_control.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:kartal/kartal.dart';
+import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/product/widget/bounceable/bounceable.dart';
+import 'package:lifeclient/product/widget/general/title/general_content_small_title.dart';
+
+@immutable
+final class GeneralSegmentedControl<T> extends StatelessWidget {
+  const GeneralSegmentedControl({
+    required this.value,
+    required this.options,
+    required this.labelBuilder,
+    required this.onChanged,
+    super.key,
+  });
+
+  final T value;
+  final List<T> options;
+  final String Function(T option) labelBuilder;
+  final ValueChanged<T> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const PagePadding.allVeryLow(),
+      decoration: BoxDecoration(
+        color: context.general.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final option in options)
+            _SegmentButton(
+              selected: option == value,
+              label: labelBuilder(option),
+              onTap: () => onChanged(option),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+final class _SegmentButton extends StatelessWidget {
+  const _SegmentButton({
+    required this.selected,
+    required this.label,
+    required this.onTap,
+  });
+
+  final bool selected;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomBounceable(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: Durations.short4,
+        padding:
+            const PagePadding.horizontalLowSymmetric() +
+            const PagePadding.vertical8Symmetric(),
+        decoration: BoxDecoration(
+          color: selected
+              ? context.general.colorScheme.primary
+              : Colors.transparent,
+          borderRadius: BorderRadius.circular(AppRadius.pill),
+        ),
+        child: GeneralContentSmallTitle(
+          value: label,
+          fontWeight: FontWeight.w700,
+          color: selected
+              ? context.general.colorScheme.onPrimary
+              : context.general.colorScheme.onSurface,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/product/widget/general/general_switch_tile.dart
+++ b/lib/product/widget/general/general_switch_tile.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:kartal/kartal.dart';
+import 'package:life_shared/life_shared.dart';
+import 'package:lifeclient/core/theme/app_context_colors.dart';
+import 'package:lifeclient/core/theme/app_radius.dart';
+import 'package:lifeclient/core/theme/app_spacing.dart';
+import 'package:lifeclient/product/utility/constants/app_icon_sizes.dart';
+import 'package:lifeclient/product/widget/general/title/general_body_title.dart';
+
+@immutable
+final class GeneralSwitchTile extends StatelessWidget {
+  const GeneralSwitchTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding:
+          const PagePadding.horizontalNormalSymmetric() +
+          const PagePadding.vertical12Symmetric(),
+      child: Row(
+        spacing: AppSpacing.sm,
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: context.appColors.coral50,
+              borderRadius: BorderRadius.circular(AppRadius.sm),
+            ),
+            padding: const PagePadding.allLow(),
+            child: Icon(
+              icon,
+              size: AppIconSizes.medium,
+              color: context.appColors.coral500,
+            ),
+          ),
+          Expanded(
+            child: GeneralBodyTitle(label, textAlign: TextAlign.start),
+          ),
+          Switch(
+            value: value,
+            onChanged: onChanged,
+            activeTrackColor: context.general.colorScheme.tertiary,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/product/widget/general/index.dart
+++ b/lib/product/widget/general/index.dart
@@ -5,6 +5,8 @@ export 'general_check_box.dart';
 export 'general_expansion_tile.dart';
 export 'general_info_banner.dart';
 export 'general_scaffold.dart';
+export 'general_segmented_control.dart';
 export 'general_status_badge.dart';
+export 'general_switch_tile.dart';
 export 'space/index.dart';
 export 'title/index.dart';


### PR DESCRIPTION
## Özet
- Ayarlar ekranı (Bildirim/Dil/Görünüm/Bize Ulaşın) yeni tasarıma göre yeniden düzenlendi
- Bildirim izni artık switch ile (checkbox yerine), dil seçimi TR/EN segmented control ile
- Bildirim izni switch'inin dil değişince titremesi düzeltildi
- Yeni reusable widget'lar: GeneralSwitchTile, GeneralSegmentedControl

<img width="300" height="650" alt="Ayarlar" src="https://github.com/user-attachments/assets/4bddbf51-466b-4d68-97cd-fb616a54d688" />

## Durum
- Esnaf Paneli bu PR'a dahil değil — zaten Profil sayfasında mevcut/bağlı, ayrı bir PR gelmeyecek
- #420'nin geri kalanı (misafir profil, hesap silme, engellenenler) bu PR'da yok

Relates to #420