### PR TITLE
vb10 bug list: misafirde Gruplar tabı gizli, talep formları giriş gerektirmiyor

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -421,7 +421,7 @@ service cloud.firestore {
 
     match /unApprovedApplications/{appId} {
       allow read: if isAdmin();
-      allow create: if isSignedIn();
+      allow create: if true;
       allow update, delete: if isAdmin();
     }
 
@@ -453,7 +453,7 @@ service cloud.firestore {
     }
     match /unApprovedCampaigns/{document} {
       allow read: if isAdmin();
-      allow create: if isSignedIn();
+      allow create: if true;
       allow update, delete: if isAdmin();
     }
 
@@ -483,7 +483,8 @@ service cloud.firestore {
     }
     match /scholarship/{scholarship} {
       allow read: if true;
-      allow write: if isAdmin();
+      allow create: if true;
+      allow update, delete: if isAdmin();
     }
     match /chainStores/{chainStore} {
       allow read: if true;

--- a/lib/features/main/news_jobs/view/news_jobs_view.dart
+++ b/lib/features/main/news_jobs/view/news_jobs_view.dart
@@ -1,8 +1,11 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kartal/kartal.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/core/theme/app_colors.dart';
+import 'package:lifeclient/features/auth/view_model/auth_state.dart';
+import 'package:lifeclient/features/auth/view_model/auth_view_model.dart';
 import 'package:lifeclient/features/community/groups/view/groups_view.dart';
 import 'package:lifeclient/features/main/event/view/event_view.dart';
 import 'package:lifeclient/features/main/news_jobs/view/sub_view/tab_news_view.dart';
@@ -34,13 +37,22 @@ final class NewsEventJobsView extends StatelessWidget {
   const NewsEventJobsView({super.key});
   @override
   Widget build(BuildContext context) {
+    final isAuthenticated =
+        ProviderScope.containerOf(context).read(authViewModelProvider)
+            is Authenticated;
+    final visibleTabs = isAuthenticated
+        ? NewsEventJobTabs.values
+        : NewsEventJobTabs.values
+              .where((tab) => tab != NewsEventJobTabs.groups)
+              .toList();
+
     return DefaultTabController(
-      length: NewsEventJobTabs.values.length,
-      child: const Scaffold(
+      length: visibleTabs.length,
+      child: Scaffold(
         body: Column(
           children: [
-            _NewsEventJobsTabBar(),
-            Expanded(child: _NewsEventJobsTabView()),
+            _NewsEventJobsTabBar(tabs: visibleTabs),
+            Expanded(child: _NewsEventJobsTabView(tabs: visibleTabs)),
           ],
         ),
       ),

--- a/lib/features/main/news_jobs/view/widget/news_jobs_tab_bar.dart
+++ b/lib/features/main/news_jobs/view/widget/news_jobs_tab_bar.dart
@@ -2,7 +2,9 @@ part of '../news_jobs_view.dart';
 
 @immutable
 final class _NewsEventJobsTabBar extends StatefulWidget {
-  const _NewsEventJobsTabBar();
+  const _NewsEventJobsTabBar({required this.tabs});
+
+  final List<NewsEventJobTabs> tabs;
 
   @override
   State<_NewsEventJobsTabBar> createState() => _NewsEventJobsTabBarState();
@@ -22,7 +24,7 @@ class _NewsEventJobsTabBarState extends State<_NewsEventJobsTabBar>
         ),
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final tabWidth = constraints.maxWidth / 3;
+            final tabWidth = constraints.maxWidth / widget.tabs.length;
             return Stack(
               children: [
                 AnimatedPositioned(
@@ -40,30 +42,14 @@ class _NewsEventJobsTabBarState extends State<_NewsEventJobsTabBar>
                 ),
                 Row(
                   children: [
-                    Expanded(
-                      child: _CustomTabButton(
-                        tab: NewsEventJobTabs.news,
-                        onPressed: () =>
-                            _changeCurrentTabView(NewsEventJobTabs.news),
-                        selectedTab: _currentTab,
+                    for (final tab in widget.tabs)
+                      Expanded(
+                        child: _CustomTabButton(
+                          tab: tab,
+                          onPressed: () => _changeCurrentTabView(tab),
+                          selectedTab: _currentTab,
+                        ),
                       ),
-                    ),
-                    Expanded(
-                      child: _CustomTabButton(
-                        tab: NewsEventJobTabs.event,
-                        onPressed: () =>
-                            _changeCurrentTabView(NewsEventJobTabs.event),
-                        selectedTab: _currentTab,
-                      ),
-                    ),
-                    Expanded(
-                      child: _CustomTabButton(
-                        tab: NewsEventJobTabs.groups,
-                        onPressed: () =>
-                            _changeCurrentTabView(NewsEventJobTabs.groups),
-                        selectedTab: _currentTab,
-                      ),
-                    ),
                   ],
                 ),
               ],
@@ -77,7 +63,7 @@ class _NewsEventJobsTabBarState extends State<_NewsEventJobsTabBar>
 
 mixin _NewsEventJobsTabMixin on State<_NewsEventJobsTabBar> {
   void _changeCurrentTabView(NewsEventJobTabs tab) {
-    DefaultTabController.maybeOf(context)?.animateTo(tab.index);
+    DefaultTabController.maybeOf(context)?.animateTo(widget.tabs.indexOf(tab));
     setState(() {
       _currentTab = tab;
     });
@@ -87,14 +73,8 @@ mixin _NewsEventJobsTabMixin on State<_NewsEventJobsTabBar> {
 
   /// Returns the left position of the selected tab indicator.
   double _leftPosition(double tabWidth) {
-    switch (_currentTab) {
-      case NewsEventJobTabs.news:
-        return WidgetSizes.spacingXxs;
-      case NewsEventJobTabs.event:
-        return tabWidth + WidgetSizes.spacingXxs;
-      case NewsEventJobTabs.groups:
-        return (tabWidth * 2) + WidgetSizes.spacingXxs;
-    }
+    final index = widget.tabs.indexOf(_currentTab);
+    return (tabWidth * index) + WidgetSizes.spacingXxs;
   }
 }
 

--- a/lib/features/main/news_jobs/view/widget/news_jobs_tab_view.dart
+++ b/lib/features/main/news_jobs/view/widget/news_jobs_tab_view.dart
@@ -2,17 +2,26 @@ part of '../news_jobs_view.dart';
 
 @immutable
 final class _NewsEventJobsTabView extends StatelessWidget {
-  const _NewsEventJobsTabView();
+  const _NewsEventJobsTabView({required this.tabs});
+
+  final List<NewsEventJobTabs> tabs;
 
   @override
   Widget build(BuildContext context) {
-    return const TabBarView(
-      physics: NeverScrollableScrollPhysics(),
-      children: [
-        TabNewsView(),
-        EventView(),
-        GroupsView(),
-      ],
+    return TabBarView(
+      physics: const NeverScrollableScrollPhysics(),
+      children: tabs.map(_pageFor).toList(),
     );
+  }
+
+  Widget _pageFor(NewsEventJobTabs tab) {
+    switch (tab) {
+      case NewsEventJobTabs.news:
+        return const TabNewsView();
+      case NewsEventJobTabs.event:
+        return const EventView();
+      case NewsEventJobTabs.groups:
+        return const GroupsView();
+    }
   }
 }

--- a/lib/product/navigation/app_router.dart
+++ b/lib/product/navigation/app_router.dart
@@ -162,10 +162,6 @@ final class PlaceRequestFormRoute extends GoRouteData
   );
 
   @override
-  String? redirect(BuildContext context, GoRouterState state) =>
-      AuthGuard.requireLogin(context, state);
-
-  @override
   Widget build(BuildContext context, GoRouterState state) =>
       const PlaceRequestForm();
 }
@@ -235,10 +231,6 @@ final class ProjectRequestFormRoute extends GoRouteData
   );
 
   @override
-  String? redirect(BuildContext context, GoRouterState state) =>
-      AuthGuard.requireLogin(context, state);
-
-  @override
   Widget build(BuildContext context, GoRouterState state) =>
       const ProjectRequestForm();
 }
@@ -251,10 +243,6 @@ final class ScholarShipRequestFormRoute extends GoRouteData
     path: 'scholarShipRequestForm',
     name: 'ScholarShip Request Form',
   );
-
-  @override
-  String? redirect(BuildContext context, GoRouterState state) =>
-      AuthGuard.requireLogin(context, state);
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>


### PR DESCRIPTION
## Değişiklikler
- Misafir (giriş yapmamış) kullanıcı "Akış" sekmesinde artık "Gruplar" alt-sekmesini görmüyor
- Yeni İşletme/Proje/Burs talebi formları artık giriş yapmadan (misafir olarak) doldurulup gönderilebiliyor — route guard'ları ve ilgili Firestore create izinleri kaldırıldı

**Güvenlik notu:** `unApprovedApplications`, `unApprovedCampaigns`, `scholarship` koleksiyonlarında create izni artık kimlik doğrulaması gerektirmiyor (`allow create: if true;`). Bilinçli bir trade-off — spam/kötüye kullanım riski var, rate limiting yok.

Relates to #416