### PR TITLE
fix(#416): misafir talep formlarinda login zorunlu + gruplar tabi gizli

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -63,6 +63,9 @@
       "selectedLocationSave": "Save for your selection",
       "updateFromMap": "Update your location"
     },
+    "speedDial": {
+      "loginRequiredHint": "Login required"
+    },
     "picker": {
       "camera": "Camera",
       "gallery": "Gallery",

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -63,6 +63,9 @@
       "selectedLocationSave": "Seçtiğin konumu kaydet",
       "updateFromMap": "Haritadan konum güncelle"
     },
+    "speedDial": {
+      "loginRequiredHint": "Giriş yapmak zorunlu"
+    },
     "picker": {
       "camera": "Kamera",
       "gallery": "Galeri",

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -421,7 +421,7 @@ service cloud.firestore {
 
     match /unApprovedApplications/{appId} {
       allow read: if isAdmin();
-      allow create: if true;
+      allow create: if isSignedIn();
       allow update, delete: if isAdmin();
     }
 
@@ -453,7 +453,7 @@ service cloud.firestore {
     }
     match /unApprovedCampaigns/{document} {
       allow read: if isAdmin();
-      allow create: if true;
+      allow create: if isSignedIn();
       allow update, delete: if isAdmin();
     }
 
@@ -483,8 +483,7 @@ service cloud.firestore {
     }
     match /scholarship/{scholarship} {
       allow read: if true;
-      allow create: if true;
-      allow update, delete: if isAdmin();
+      allow write: if isAdmin();
     }
     match /chainStores/{chainStore} {
       allow read: if true;

--- a/lib/features/main/news_jobs/view/news_jobs_view.dart
+++ b/lib/features/main/news_jobs/view/news_jobs_view.dart
@@ -37,25 +37,29 @@ final class NewsEventJobsView extends StatelessWidget {
   const NewsEventJobsView({super.key});
   @override
   Widget build(BuildContext context) {
-    final isAuthenticated =
-        ProviderScope.containerOf(context).read(authViewModelProvider)
-            is Authenticated;
-    final visibleTabs = isAuthenticated
-        ? NewsEventJobTabs.values
-        : NewsEventJobTabs.values
-              .where((tab) => tab != NewsEventJobTabs.groups)
-              .toList();
+    return Consumer(
+      builder: (context, ref, child) {
+        final isAuthenticated =
+            ref.watch(authViewModelProvider).isAuthenticated;
+        final visibleTabs = isAuthenticated
+            ? NewsEventJobTabs.values
+            : NewsEventJobTabs.values
+                  .where((tab) => tab != NewsEventJobTabs.groups)
+                  .toList();
 
-    return DefaultTabController(
-      length: visibleTabs.length,
-      child: Scaffold(
-        body: Column(
-          children: [
-            _NewsEventJobsTabBar(tabs: visibleTabs),
-            Expanded(child: _NewsEventJobsTabView(tabs: visibleTabs)),
-          ],
-        ),
-      ),
+        return DefaultTabController(
+          key: ValueKey(visibleTabs.length),
+          length: visibleTabs.length,
+          child: Scaffold(
+            body: Column(
+              children: [
+                _NewsEventJobsTabBar(tabs: visibleTabs),
+                Expanded(child: _NewsEventJobsTabView(tabs: visibleTabs)),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/main/news_jobs/view/widget/news_jobs_tab_bar.dart
+++ b/lib/features/main/news_jobs/view/widget/news_jobs_tab_bar.dart
@@ -63,7 +63,9 @@ class _NewsEventJobsTabBarState extends State<_NewsEventJobsTabBar>
 
 mixin _NewsEventJobsTabMixin on State<_NewsEventJobsTabBar> {
   void _changeCurrentTabView(NewsEventJobTabs tab) {
-    DefaultTabController.maybeOf(context)?.animateTo(widget.tabs.indexOf(tab));
+    final index = widget.tabs.indexOf(tab);
+    if (index == -1) return;
+    DefaultTabController.maybeOf(context)?.animateTo(index);
     setState(() {
       _currentTab = tab;
     });
@@ -73,7 +75,7 @@ mixin _NewsEventJobsTabMixin on State<_NewsEventJobsTabBar> {
 
   /// Returns the left position of the selected tab indicator.
   double _leftPosition(double tabWidth) {
-    final index = widget.tabs.indexOf(_currentTab);
+    final index = widget.tabs.indexOf(_currentTab).clamp(0, widget.tabs.length - 1);
     return (tabWidth * index) + WidgetSizes.spacingXxs;
   }
 }

--- a/lib/product/init/language/locale_keys.g.dart
+++ b/lib/product/init/language/locale_keys.g.dart
@@ -61,6 +61,8 @@ abstract class  LocaleKeys {
   static const component_mapPicker_selectedLocationSave = 'component.mapPicker.selectedLocationSave';
   static const component_mapPicker_updateFromMap = 'component.mapPicker.updateFromMap';
   static const component_mapPicker = 'component.mapPicker';
+  static const component_speedDial_loginRequiredHint = 'component.speedDial.loginRequiredHint';
+  static const component_speedDial = 'component.speedDial';
   static const component_picker_camera = 'component.picker.camera';
   static const component_picker_gallery = 'component.picker.gallery';
   static const component_picker_cropperTitle = 'component.picker.cropperTitle';
@@ -364,7 +366,11 @@ abstract class  LocaleKeys {
   static const favorite_title = 'favorite.title';
   static const favorite_search = 'favorite.search';
   static const favorite_clearAllButton = 'favorite.clearAllButton';
-  static const favorite_noBusinessFound = 'favorite.noBusinessFound';
+  static const favorite_emptyTitle = 'favorite.emptyTitle';
+  static const favorite_emptyDescription = 'favorite.emptyDescription';
+  static const favorite_emptyCta = 'favorite.emptyCta';
+  static const favorite_searchEmptyTitle = 'favorite.searchEmptyTitle';
+  static const favorite_searchEmptyDescription = 'favorite.searchEmptyDescription';
   static const favorite_clearAllDialog_content = 'favorite.clearAllDialog.content';
   static const favorite_clearAllDialog = 'favorite.clearAllDialog';
   static const favorite_deleteDialog_content = 'favorite.deleteDialog.content';

--- a/lib/product/navigation/app_router.dart
+++ b/lib/product/navigation/app_router.dart
@@ -162,6 +162,10 @@ final class PlaceRequestFormRoute extends GoRouteData
   );
 
   @override
+  String? redirect(BuildContext context, GoRouterState state) =>
+      AuthGuard.requireLogin(context, state);
+
+  @override
   Widget build(BuildContext context, GoRouterState state) =>
       const PlaceRequestForm();
 }
@@ -231,6 +235,10 @@ final class ProjectRequestFormRoute extends GoRouteData
   );
 
   @override
+  String? redirect(BuildContext context, GoRouterState state) =>
+      AuthGuard.requireLogin(context, state);
+
+  @override
   Widget build(BuildContext context, GoRouterState state) =>
       const ProjectRequestForm();
 }
@@ -243,6 +251,10 @@ final class ScholarShipRequestFormRoute extends GoRouteData
     path: 'scholarShipRequestForm',
     name: 'ScholarShip Request Form',
   );
+
+  @override
+  String? redirect(BuildContext context, GoRouterState state) =>
+      AuthGuard.requireLogin(context, state);
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>

--- a/lib/product/widget/speed_dial/custom_speed_dial_child.dart
+++ b/lib/product/widget/speed_dial/custom_speed_dial_child.dart
@@ -1,6 +1,9 @@
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:go_router/go_router.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+import 'package:lifeclient/product/utility/decorations/empty_box.dart';
 import 'package:lifeclient/product/widget/general/index.dart';
 
 final class CustomSpeedDialRouteChild extends SpeedDialChild {
@@ -8,8 +11,20 @@ final class CustomSpeedDialRouteChild extends SpeedDialChild {
     required BuildContext context,
     required String location,
     required String label,
+    bool showLoginRequiredHint = false,
   }) : super(
-         child: GeneralBodyTitle(label),
+         child: Column(
+           mainAxisSize: MainAxisSize.min,
+           children: [
+             GeneralBodyTitle(label),
+             if (showLoginRequiredHint) ...[
+               const EmptyBox.xxSmallHeight(),
+               GeneralContentSmallTitle(
+                 value: LocaleKeys.component_speedDial_loginRequiredHint.tr(),
+               ),
+             ],
+           ],
+         ),
          onTap: () => context.go(location),
        );
 }

--- a/lib/sub_feature/main_tab/main_tab_view.dart
+++ b/lib/sub_feature/main_tab/main_tab_view.dart
@@ -12,6 +12,8 @@ import 'package:lifeclient/core/theme/app_radius.dart';
 import 'package:lifeclient/core/theme/app_shadows.dart';
 import 'package:lifeclient/core/theme/app_spacing.dart';
 import 'package:lifeclient/core/theme/app_text.dart';
+import 'package:lifeclient/features/auth/view_model/auth_state.dart';
+import 'package:lifeclient/features/auth/view_model/auth_view_model.dart';
 import 'package:lifeclient/features/community/widget/soft_icon_box.dart';
 import 'package:lifeclient/product/generated/assets.gen.dart';
 import 'package:lifeclient/product/init/language/locale_keys.g.dart';

--- a/lib/sub_feature/main_tab/widget/main_fab_button.dart
+++ b/lib/sub_feature/main_tab/widget/main_fab_button.dart
@@ -9,6 +9,7 @@ final class _SpeedDialFabWidget extends ConsumerWidget {
     final isScrolledBottom = ref
         .watch(mainTabViewModelProvider)
         .isScrolledBottom;
+    final isAuthenticated = ref.watch(authViewModelProvider).isAuthenticated;
 
     return AnimatedScale(
       duration: Durations.medium2,
@@ -21,6 +22,7 @@ final class _SpeedDialFabWidget extends ConsumerWidget {
                 context: context,
                 location: e.location,
                 label: e.title,
+                showLoginRequiredHint: !isAuthenticated,
               ),
             )
             .toList(),


### PR DESCRIPTION
## Özet
- PR #428 ile misafirlere açılan 3 talep formu (esnaf/proje/burs) route guard + Firestore rule değişikliği ekip kararıyla geri alındı — formlar tekrar login zorunlu.
- Bunun yerine misafir FAB kartlarında küçük "Giriş yapmak zorunlu" ipucu gösteriliyor (mevcut pill button içinde, ayrı bir positioning sistemine dokunmadan).
- #428'in "Gruplar tabı misafirden gizli" kısmı ve review-fix'leri (isAuthenticated extension, Consumer+TabController key reaktivitesi, indexOf(-1) guard) KORUNDU.

## Değişen dosyalar (9)
- `lib/product/navigation/app_router.dart` — 3 route'a `AuthGuard.requireLogin` redirect'i geri eklendi
- `firebase/firestore.rules` — `unApprovedApplications`/`unApprovedCampaigns`/`scholarship` create kuralları eski haline (`isSignedIn()`/`isAdmin()`) döndü
- `lib/features/main/news_jobs/view/news_jobs_view.dart` — Gruplar tabı misafirden gizli (korunuyor)
- `lib/features/main/news_jobs/view/widget/news_jobs_tab_bar.dart` — indexOf(-1) guard (korunuyor)
- `lib/product/widget/speed_dial/custom_speed_dial_child.dart` — pill içine login-required ipucu satırı
- `lib/sub_feature/main_tab/main_tab_view.dart` / `main_fab_button.dart` — `isAuthenticated` okunup child'a geçiliyor
- `assets/translations/tr.json` / `en.json` — `component.speedDial.loginRequiredHint` key'i

## Not
Filtre listesinde ayrı bir bug daha tespit edildi: `approvedApplications` için Firestore composite index eksik (`category.value + cityId + createdAt`). Prod'da reprodüklendi, ekip lideri onayladı. Bu PR'ın kapsamı dışında — index prod console'dan oluşturuldu, kalıcı fix (`firestore.indexes.json`) ayrı takip edilecek.

