### PR TITLE
fix(home): gercek Firestore sayimlariyla mekan sayisi tutarsizligini gider

### DIFF
--- a/lib/features/main/home/provider/home_state.dart
+++ b/lib/features/main/home/provider/home_state.dart
@@ -12,6 +12,8 @@ final class HomeState extends Equatable {
     this.townCodes = const {},
     this.openNow = false,
     this.favoritesOnly = false,
+    this.totalPlaceCount = 0,
+    this.categoryPlaceCounts = const {},
   });
 
   final List<CategoryModel> categories;
@@ -33,6 +35,9 @@ final class HomeState extends Equatable {
   /// if true, the data is loading for a new sorting/filter selection
   final bool isLoading;
 
+  final int totalPlaceCount;
+  final Map<int, int> categoryPlaceCounts;
+
   bool get hasActiveFilters =>
       categoryValues.isNotEmpty ||
       townCodes.isNotEmpty ||
@@ -52,6 +57,8 @@ final class HomeState extends Equatable {
         townCodes,
         openNow,
         favoritesOnly,
+        totalPlaceCount,
+        categoryPlaceCounts,
       ];
 
   HomeState copyWith({
@@ -63,6 +70,8 @@ final class HomeState extends Equatable {
     Set<int>? townCodes,
     bool? openNow,
     bool? favoritesOnly,
+    int? totalPlaceCount,
+    Map<int, int>? categoryPlaceCounts,
   }) {
     return HomeState(
       categories: categories ?? this.categories,
@@ -73,6 +82,8 @@ final class HomeState extends Equatable {
       townCodes: townCodes ?? this.townCodes,
       openNow: openNow ?? this.openNow,
       favoritesOnly: favoritesOnly ?? this.favoritesOnly,
+      totalPlaceCount: totalPlaceCount ?? this.totalPlaceCount,
+      categoryPlaceCounts: categoryPlaceCounts ?? this.categoryPlaceCounts,
     );
   }
 }

--- a/lib/features/main/home/provider/home_view_model.dart
+++ b/lib/features/main/home/provider/home_view_model.dart
@@ -19,10 +19,39 @@ final class HomeViewModel extends _$HomeViewModel with ProjectDependencyMixin {
     final categories = ref.read(productProviderState).categoryItems;
     final isHomeViewGrid =
         ref.read(productProviderState.notifier).isHomeViewGrid;
+    unawaited(Future.microtask(_fetchTotalPlaceCount));
     return HomeState(
       categories: categories,
       isGridView: isHomeViewGrid,
     );
+  }
+
+  Future<void> _fetchTotalPlaceCount() async {
+    final selectedCity = ref.read(productProviderState).selectedCity;
+    final sortingType = state.sortingType;
+
+    Future<int> countFor(Set<int> categoryValues) async {
+      final snapshot = await buildApprovedQuery(
+        cityId: selectedCity.documentId,
+        categoryValues: categoryValues,
+        townCodes: const {},
+        sortingType: sortingType,
+      ).count().get();
+      return snapshot.count ?? 0;
+    }
+
+    final total = await countFor(const {});
+    if (ref.mounted) state = state.copyWith(totalPlaceCount: total);
+
+    final categoryCounts = await Future.wait(
+      state.categories.map(
+        (category) async =>
+            MapEntry(category.value, await countFor({category.value})),
+      ),
+    );
+
+    if (!ref.mounted) return;
+    state = state.copyWith(categoryPlaceCounts: Map.fromEntries(categoryCounts));
   }
 
   CollectionReference<StoreModel?> fetchApprovedCollectionReference() {

--- a/lib/features/main/home/provider/home_view_model.g.dart
+++ b/lib/features/main/home/provider/home_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$HomeViewModel extends $Notifier<HomeState> {
   HomeState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<HomeState, HomeState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$HomeViewModel extends $Notifier<HomeState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/main/home/view/home_view.dart
+++ b/lib/features/main/home/view/home_view.dart
@@ -24,7 +24,6 @@ import 'package:lifeclient/product/utility/decorations/empty_box.dart';
 import 'package:lifeclient/product/utility/extension/category_visual.dart';
 import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
 import 'package:lifeclient/product/utility/mixin/notification_type_mixin.dart';
-import 'package:lifeclient/product/utility/mock/place_meta_mock.dart';
 import 'package:lifeclient/product/widget/card/general_place_card.dart';
 import 'package:lifeclient/product/widget/card/place/general_place_grid_card.dart';
 import 'package:lifeclient/product/widget/general/general_not_found_widget.dart';
@@ -79,20 +78,13 @@ class _HomeViewState extends ConsumerState<HomeView>
 final class _HomeHeaderBlock extends ConsumerWidget {
   const _HomeHeaderBlock();
 
-  static const _otherCategoryValue = 1000;
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final city = ref
         .watch(ProjectDependencyItems.productProviderState)
         .selectedCity
         .description;
-    final categoryValues = ref
-        .watch(homeViewModelProvider)
-        .categories
-        .where((e) => e.value != _otherCategoryValue)
-        .map((e) => e.value);
-    final total = CategoryCountMock.total(categoryValues);
+    final total = ref.watch(homeViewModelProvider).totalPlaceCount;
 
     return SliverPadding(
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),

--- a/lib/features/main/home/view/widget/home_categories_area.dart
+++ b/lib/features/main/home/view/widget/home_categories_area.dart
@@ -23,7 +23,7 @@ final class _HomeCategoryCards extends ConsumerWidget {
         vm.categories.where((e) => e.value != _otherCategoryValue).toList()
           ..sort((a, b) => a.displayName.length.compareTo(b.displayName.length));
     final visible = categories.take(_maxCategoryItemLength).toList();
-    final total = CategoryCountMock.total(visible.map((e) => e.value));
+    final total = vm.totalPlaceCount;
 
     return SingleChildScrollView(
       key: const Key('homeCategoriesList'),
@@ -46,7 +46,7 @@ final class _HomeCategoryCards extends ConsumerWidget {
             _CategoryCard(
               key: Key('categoryCard_${category.value}'),
               name: category.displayName,
-              count: CategoryCountMock.forValue(category.value),
+              count: vm.categoryPlaceCounts[category.value] ?? 0,
               icon: CategoryVisual.iconFor(category),
               accent: CategoryVisual.accentFor(category),
               isActive: selected.contains(category.value),

--- a/lib/product/utility/mock/place_meta_mock.dart
+++ b/lib/product/utility/mock/place_meta_mock.dart
@@ -25,14 +25,3 @@ final class PlaceMetaMock {
 
   String get distanceLabel => '${distanceKm.toStringAsFixed(1)} km';
 }
-
-/// Placeholder per-category place counts for the category chips + eyebrow,
-/// until the backend exposes real aggregates. Deterministic from category value.
-final class CategoryCountMock {
-  const CategoryCountMock._();
-
-  static int forValue(int value) => 8 + value.abs() % 40;
-
-  static int total(Iterable<int> values) =>
-      values.fold(0, (sum, value) => sum + forValue(value));
-}


### PR DESCRIPTION
## Özet
Ana sayfa başlığındaki mekan sayısı ("407 MEKAN") ile "Tümü" filtre chip'indeki sayı ("86") farklı kapsamlarda toplanan sahte `CategoryCountMock` formülünden geliyordu ve birbirini tutmuyordu. Mock tamamen kaldırıldı; yerine seçili şehre göre filtrelenmiş gerçek Firestore `count()` aggregate sorguları geldi (toplam + kategori bazlı sayımlar).

## Değişen dosyalar
- `lib/features/main/home/provider/home_state.dart` — count alanları eklendi
- `lib/features/main/home/provider/home_view_model.dart` — Firestore `count()` aggregate sorguları
- `lib/features/main/home/view/home_view.dart` — mock yerine state'ten gelen gerçek sayı
- `lib/features/main/home/view/widget/home_categories_area.dart` — kategori chip sayıları gerçek veriden
- `lib/product/utility/mock/place_meta_mock.dart` — `CategoryCountMock` kaldırıldı

## Bilinen takip (bu PR'ın kapsamı dışında)
Prod'da `approvedApplications` koleksiyonu için composite index eksik olduğu tespit edildi (`cityId + category.value + createdAt`). Index deploy edilmeden kategori bazlı sayımlar sessizce 0 dönebilir. Index'in ayrıca eklenip deploy edilmesi gerekiyor — ayrı takip edilecek.

## Checklist
- [x] flutter analyze hata yok
- [x] Kod proje kurallarına uyuyor

Closes #435