### PR TITLE
refactor(home): kategori chip sayaclarini ve header mekan sayisini kaldir

### DIFF
--- a/lib/features/main/home/provider/home_state.dart
+++ b/lib/features/main/home/provider/home_state.dart
@@ -12,6 +12,8 @@ final class HomeState extends Equatable {
     this.townCodes = const {},
     this.openNow = false,
     this.favoritesOnly = false,
+    this.totalPlaceCount = 0,
+    this.categoryPlaceCounts = const {},
   });
 
   final List<CategoryModel> categories;
@@ -33,6 +35,9 @@ final class HomeState extends Equatable {
   /// if true, the data is loading for a new sorting/filter selection
   final bool isLoading;
 
+  final int totalPlaceCount;
+  final Map<int, int> categoryPlaceCounts;
+
   bool get hasActiveFilters =>
       categoryValues.isNotEmpty ||
       townCodes.isNotEmpty ||
@@ -52,6 +57,8 @@ final class HomeState extends Equatable {
         townCodes,
         openNow,
         favoritesOnly,
+        totalPlaceCount,
+        categoryPlaceCounts,
       ];
 
   HomeState copyWith({
@@ -63,6 +70,8 @@ final class HomeState extends Equatable {
     Set<int>? townCodes,
     bool? openNow,
     bool? favoritesOnly,
+    int? totalPlaceCount,
+    Map<int, int>? categoryPlaceCounts,
   }) {
     return HomeState(
       categories: categories ?? this.categories,
@@ -73,6 +82,8 @@ final class HomeState extends Equatable {
       townCodes: townCodes ?? this.townCodes,
       openNow: openNow ?? this.openNow,
       favoritesOnly: favoritesOnly ?? this.favoritesOnly,
+      totalPlaceCount: totalPlaceCount ?? this.totalPlaceCount,
+      categoryPlaceCounts: categoryPlaceCounts ?? this.categoryPlaceCounts,
     );
   }
 }

--- a/lib/features/main/home/provider/home_state.dart
+++ b/lib/features/main/home/provider/home_state.dart
@@ -12,8 +12,6 @@ final class HomeState extends Equatable {
     this.townCodes = const {},
     this.openNow = false,
     this.favoritesOnly = false,
-    this.totalPlaceCount = 0,
-    this.categoryPlaceCounts = const {},
   });
 
   final List<CategoryModel> categories;
@@ -35,9 +33,6 @@ final class HomeState extends Equatable {
   /// if true, the data is loading for a new sorting/filter selection
   final bool isLoading;
 
-  final int totalPlaceCount;
-  final Map<int, int> categoryPlaceCounts;
-
   bool get hasActiveFilters =>
       categoryValues.isNotEmpty ||
       townCodes.isNotEmpty ||
@@ -57,8 +52,6 @@ final class HomeState extends Equatable {
         townCodes,
         openNow,
         favoritesOnly,
-        totalPlaceCount,
-        categoryPlaceCounts,
       ];
 
   HomeState copyWith({
@@ -70,8 +63,6 @@ final class HomeState extends Equatable {
     Set<int>? townCodes,
     bool? openNow,
     bool? favoritesOnly,
-    int? totalPlaceCount,
-    Map<int, int>? categoryPlaceCounts,
   }) {
     return HomeState(
       categories: categories ?? this.categories,
@@ -82,8 +73,6 @@ final class HomeState extends Equatable {
       townCodes: townCodes ?? this.townCodes,
       openNow: openNow ?? this.openNow,
       favoritesOnly: favoritesOnly ?? this.favoritesOnly,
-      totalPlaceCount: totalPlaceCount ?? this.totalPlaceCount,
-      categoryPlaceCounts: categoryPlaceCounts ?? this.categoryPlaceCounts,
     );
   }
 }

--- a/lib/features/main/home/provider/home_view_model.dart
+++ b/lib/features/main/home/provider/home_view_model.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -19,37 +17,10 @@ final class HomeViewModel extends _$HomeViewModel with ProjectDependencyMixin {
     final categories = ref.read(productProviderState).categoryItems;
     final isHomeViewGrid =
         ref.read(productProviderState.notifier).isHomeViewGrid;
-    unawaited(Future.microtask(_fetchTotalPlaceCount));
     return HomeState(
       categories: categories,
       isGridView: isHomeViewGrid,
     );
-  }
-
-  Future<void> _fetchTotalPlaceCount() async {
-    final total = await _countApproved(const {});
-    if (ref.mounted) state = state.copyWith(totalPlaceCount: total);
-
-    final categoryCounts = await Future.wait(
-      state.categories.map(
-        (category) async =>
-            MapEntry(category.value, await _countApproved({category.value})),
-      ),
-    );
-
-    if (!ref.mounted) return;
-    state = state.copyWith(categoryPlaceCounts: Map.fromEntries(categoryCounts));
-  }
-
-  Future<int> _countApproved(Set<int> categoryValues) async {
-    final selectedCity = ref.read(productProviderState).selectedCity;
-    final snapshot = await buildApprovedQuery(
-      cityId: selectedCity.documentId,
-      categoryValues: categoryValues,
-      townCodes: const {},
-      sortingType: state.sortingType,
-    ).count().get();
-    return snapshot.count ?? 0;
   }
 
   CollectionReference<StoreModel?> fetchApprovedCollectionReference() {

--- a/lib/features/main/home/provider/home_view_model.dart
+++ b/lib/features/main/home/provider/home_view_model.dart
@@ -19,10 +19,39 @@ final class HomeViewModel extends _$HomeViewModel with ProjectDependencyMixin {
     final categories = ref.read(productProviderState).categoryItems;
     final isHomeViewGrid =
         ref.read(productProviderState.notifier).isHomeViewGrid;
+    unawaited(Future.microtask(_fetchTotalPlaceCount));
     return HomeState(
       categories: categories,
       isGridView: isHomeViewGrid,
     );
+  }
+
+  Future<void> _fetchTotalPlaceCount() async {
+    final selectedCity = ref.read(productProviderState).selectedCity;
+    final sortingType = state.sortingType;
+
+    Future<int> countFor(Set<int> categoryValues) async {
+      final snapshot = await buildApprovedQuery(
+        cityId: selectedCity.documentId,
+        categoryValues: categoryValues,
+        townCodes: const {},
+        sortingType: sortingType,
+      ).count().get();
+      return snapshot.count ?? 0;
+    }
+
+    final total = await countFor(const {});
+    if (ref.mounted) state = state.copyWith(totalPlaceCount: total);
+
+    final categoryCounts = await Future.wait(
+      state.categories.map(
+        (category) async =>
+            MapEntry(category.value, await countFor({category.value})),
+      ),
+    );
+
+    if (!ref.mounted) return;
+    state = state.copyWith(categoryPlaceCounts: Map.fromEntries(categoryCounts));
   }
 
   CollectionReference<StoreModel?> fetchApprovedCollectionReference() {

--- a/lib/features/main/home/provider/home_view_model.dart
+++ b/lib/features/main/home/provider/home_view_model.dart
@@ -27,31 +27,29 @@ final class HomeViewModel extends _$HomeViewModel with ProjectDependencyMixin {
   }
 
   Future<void> _fetchTotalPlaceCount() async {
-    final selectedCity = ref.read(productProviderState).selectedCity;
-    final sortingType = state.sortingType;
-
-    Future<int> countFor(Set<int> categoryValues) async {
-      final snapshot = await buildApprovedQuery(
-        cityId: selectedCity.documentId,
-        categoryValues: categoryValues,
-        townCodes: const {},
-        sortingType: sortingType,
-      ).count().get();
-      return snapshot.count ?? 0;
-    }
-
-    final total = await countFor(const {});
+    final total = await _countApproved(const {});
     if (ref.mounted) state = state.copyWith(totalPlaceCount: total);
 
     final categoryCounts = await Future.wait(
       state.categories.map(
         (category) async =>
-            MapEntry(category.value, await countFor({category.value})),
+            MapEntry(category.value, await _countApproved({category.value})),
       ),
     );
 
     if (!ref.mounted) return;
     state = state.copyWith(categoryPlaceCounts: Map.fromEntries(categoryCounts));
+  }
+
+  Future<int> _countApproved(Set<int> categoryValues) async {
+    final selectedCity = ref.read(productProviderState).selectedCity;
+    final snapshot = await buildApprovedQuery(
+      cityId: selectedCity.documentId,
+      categoryValues: categoryValues,
+      townCodes: const {},
+      sortingType: state.sortingType,
+    ).count().get();
+    return snapshot.count ?? 0;
   }
 
   CollectionReference<StoreModel?> fetchApprovedCollectionReference() {

--- a/lib/features/main/home/provider/home_view_model.g.dart
+++ b/lib/features/main/home/provider/home_view_model.g.dart
@@ -47,7 +47,7 @@ abstract class _$HomeViewModel extends $Notifier<HomeState> {
   HomeState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<HomeState, HomeState>;
     final element =
         ref.element
@@ -57,6 +57,6 @@ abstract class _$HomeViewModel extends $Notifier<HomeState> {
               Object?,
               Object?
             >;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/lib/features/main/home/view/home_view.dart
+++ b/lib/features/main/home/view/home_view.dart
@@ -84,7 +84,6 @@ final class _HomeHeaderBlock extends ConsumerWidget {
         .watch(ProjectDependencyItems.productProviderState)
         .selectedCity
         .description;
-    final total = ref.watch(homeViewModelProvider).totalPlaceCount;
 
     return SliverPadding(
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
@@ -97,8 +96,7 @@ final class _HomeHeaderBlock extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    '${city.toUpperCase()} · $total '
-                    '${LocaleKeys.home_placesUpper.tr()}',
+                    city.toUpperCase(),
                     style: AppText.eyebrow,
                   ),
                   const SizedBox(height: AppSpacing.xxs),

--- a/lib/features/main/home/view/home_view.dart
+++ b/lib/features/main/home/view/home_view.dart
@@ -24,7 +24,6 @@ import 'package:lifeclient/product/utility/decorations/empty_box.dart';
 import 'package:lifeclient/product/utility/extension/category_visual.dart';
 import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
 import 'package:lifeclient/product/utility/mixin/notification_type_mixin.dart';
-import 'package:lifeclient/product/utility/mock/place_meta_mock.dart';
 import 'package:lifeclient/product/widget/card/general_place_card.dart';
 import 'package:lifeclient/product/widget/card/place/general_place_grid_card.dart';
 import 'package:lifeclient/product/widget/general/general_not_found_widget.dart';
@@ -79,20 +78,13 @@ class _HomeViewState extends ConsumerState<HomeView>
 final class _HomeHeaderBlock extends ConsumerWidget {
   const _HomeHeaderBlock();
 
-  static const _otherCategoryValue = 1000;
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final city = ref
         .watch(ProjectDependencyItems.productProviderState)
         .selectedCity
         .description;
-    final categoryValues = ref
-        .watch(homeViewModelProvider)
-        .categories
-        .where((e) => e.value != _otherCategoryValue)
-        .map((e) => e.value);
-    final total = CategoryCountMock.total(categoryValues);
+    final total = ref.watch(homeViewModelProvider).totalPlaceCount;
 
     return SliverPadding(
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),

--- a/lib/features/main/home/view/widget/home_categories_area.dart
+++ b/lib/features/main/home/view/widget/home_categories_area.dart
@@ -23,7 +23,7 @@ final class _HomeCategoryCards extends ConsumerWidget {
         vm.categories.where((e) => e.value != _otherCategoryValue).toList()
           ..sort((a, b) => a.displayName.length.compareTo(b.displayName.length));
     final visible = categories.take(_maxCategoryItemLength).toList();
-    final total = CategoryCountMock.total(visible.map((e) => e.value));
+    final total = vm.totalPlaceCount;
 
     return SingleChildScrollView(
       key: const Key('homeCategoriesList'),
@@ -46,7 +46,7 @@ final class _HomeCategoryCards extends ConsumerWidget {
             _CategoryCard(
               key: Key('categoryCard_${category.value}'),
               name: category.displayName,
-              count: CategoryCountMock.forValue(category.value),
+              count: vm.categoryPlaceCounts[category.value] ?? 0,
               icon: CategoryVisual.iconFor(category),
               accent: CategoryVisual.accentFor(category),
               isActive: selected.contains(category.value),

--- a/lib/features/main/home/view/widget/home_categories_area.dart
+++ b/lib/features/main/home/view/widget/home_categories_area.dart
@@ -23,7 +23,6 @@ final class _HomeCategoryCards extends ConsumerWidget {
         vm.categories.where((e) => e.value != _otherCategoryValue).toList()
           ..sort((a, b) => a.displayName.length.compareTo(b.displayName.length));
     final visible = categories.take(_maxCategoryItemLength).toList();
-    final total = vm.totalPlaceCount;
 
     return SingleChildScrollView(
       key: const Key('homeCategoriesList'),
@@ -34,7 +33,6 @@ final class _HomeCategoryCards extends ConsumerWidget {
           _CategoryCard(
             key: const Key('categoryCard_all'),
             name: LocaleKeys.home_allCategory.tr(),
-            count: total,
             icon: CategoryVisual.allIcon,
             accent: AppColors.coral,
             isActive: selected.isEmpty,
@@ -46,7 +44,6 @@ final class _HomeCategoryCards extends ConsumerWidget {
             _CategoryCard(
               key: Key('categoryCard_${category.value}'),
               name: category.displayName,
-              count: vm.categoryPlaceCounts[category.value] ?? 0,
               icon: CategoryVisual.iconFor(category),
               accent: CategoryVisual.accentFor(category),
               isActive: selected.contains(category.value),
@@ -63,7 +60,6 @@ final class _HomeCategoryCards extends ConsumerWidget {
 final class _CategoryCard extends StatelessWidget {
   const _CategoryCard({
     required this.name,
-    required this.count,
     required this.icon,
     required this.accent,
     required this.isActive,
@@ -72,7 +68,6 @@ final class _CategoryCard extends StatelessWidget {
   });
 
   final String name;
-  final int count;
   final IconData icon;
   final Color accent;
   final bool isActive;
@@ -114,14 +109,6 @@ final class _CategoryCard extends StatelessWidget {
                   name,
                   style: AppText.body.copyWith(
                     color: foreground,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.xxs),
-                Text(
-                  '$count',
-                  style: AppText.caption.copyWith(
-                    color: isActive ? AppColors.white : AppColors.ink400,
                     fontWeight: FontWeight.w700,
                   ),
                 ),

--- a/lib/product/utility/mock/place_meta_mock.dart
+++ b/lib/product/utility/mock/place_meta_mock.dart
@@ -25,14 +25,3 @@ final class PlaceMetaMock {
 
   String get distanceLabel => '${distanceKm.toStringAsFixed(1)} km';
 }
-
-/// Placeholder per-category place counts for the category chips + eyebrow,
-/// until the backend exposes real aggregates. Deterministic from category value.
-final class CategoryCountMock {
-  const CategoryCountMock._();
-
-  static int forValue(int value) => 8 + value.abs() % 40;
-
-  static int total(Iterable<int> values) =>
-      values.fold(0, (sum, value) => sum + forValue(value));
-}


### PR DESCRIPTION
## Description
Kategori chip'lerindeki (Tumu/OTEL/SPOR vb.) ve header'daki mekan sayilari kaldirildi. Bu sayilar per-kategori Firestore `count()` aggregate sorgusu gerektiriyordu; gosterilen kategori sayisindan bagimsiz olarak her kategori icin ayri bir sorgu atiliyordu, bu da gereksiz maliyet olusturuyordu. UI artik sadece isim/ikon gosteriyor, hicbir `count()` cagrisi yapilmiyor.


## Related Issues
Closes #435