### PR TITLE
fix(scholarship): validate document size at pick time

### DIFF
--- a/lib/features/sub_feature/forms/scholarship_request/view/mixin/scholarship_request_form_mixin.dart
+++ b/lib/features/sub_feature/forms/scholarship_request/view/mixin/scholarship_request_form_mixin.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/sub_feature/forms/request_form.dart';
 import 'package:lifeclient/features/sub_feature/forms/scholarship_request/provider/scholarship_request_provider.dart';
 import 'package:lifeclient/features/sub_feature/forms/scholarship_request/view/scholarship_request_form.dart';
@@ -64,6 +65,16 @@ mixin ScholarshipRequestFormMixin
 
   void updatePdfFile(File? file) {
     selectedPdfFile = file;
+  }
+
+  /// Rejects the picked document before it reaches the form when it exceeds
+  /// the same limit [ScholarshipRequestProvider] uploads with.
+  bool validatePdfSize(File file) {
+    if (file.lengthSync() <= FileSizes.small.toByte) return true;
+    appProvider.showSnackbarMessage(
+      LocaleKeys.requestScholarship_error_fileSizeError.tr(),
+    );
+    return false;
   }
 
   void updateKVKK({required bool value}) {

--- a/lib/features/sub_feature/forms/scholarship_request/view/scholarship_request_form.dart
+++ b/lib/features/sub_feature/forms/scholarship_request/view/scholarship_request_form.dart
@@ -88,6 +88,7 @@ final class _ScholarshipRequestFormState
           ),
           UploadFileSection(
             hintText: LocaleKeys.requestScholarship_pdfHint,
+            fileValidator: validatePdfSize,
             onFilePicked: updatePdfFile,
           ),
           const _UploadSizeInfo(),


### PR DESCRIPTION
Burs formu UploadFileSection'a fileValidator gecmiyordu; boyut yalnizca upload sirasinda FileSizes.small (100 KB) ile kontrol ediliyordu. 144117 byte'lik bir PDF secim asamasindan gecip "talep olustur"da StorageService sizeLimit hatasina dusuyordu. Ayni limit artik secim aninda uygulanip kullaniciya snackbar ile bildiriliyor; merchant_application, showcase ve store_edit formlarindaki desenle ayni.