### PR TITLE
fix: iOS 26 paylaşım çökmesi için share_plus sürümünü yükselt

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id 'dev.flutter.flutter-plugin-loader' version '1.0.0'
-    id 'com.android.application' version '8.12.0' apply false
+    id 'com.android.application' version '8.12.1' apply false
     id 'org.jetbrains.kotlin.android' version '2.3.10' apply false
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -120,6 +120,9 @@ dependencies:
 dependency_overrides:
   device_info_plus: ^12.3.0
   sqflite_android: ^2.4.2+2
+  # kartal ^11.0.0'a kilitliyor; 12.0.1 iOS 26 paylasim cokmesini duzeltiyor.
+  # kartal share_plus kisitini yukseltince bu override kaldirilacak.
+  share_plus: ^12.0.2
 
 dev_dependencies:
   build_runner: ^2.10.5


### PR DESCRIPTION
## Özet
- `dependency_overrides` ile **share_plus 11.1.0 → 12.0.2**
- Android Gradle Plugin **8.12.0 → 8.12.1** (share_plus 12+ şartı)

Kod dosyasına dokunulmadı.

## Sorun
iOS 26'da `sharePositionOrigin` verilmeden yapılan paylaşım çağrıları çöküyordu. #444'teki iki madde de bundan kaynaklanıyordu:
- Akış haberlerindeki paylaş ikonu
- Slider mekan detayındaki paylaş butonu

share_plus 12.0.1 bunu kaynağında düzeltiyor (`isIpad` koşulu eklendi — Xcode 26'dan beri `popoverPresentationController` iPhone'da da non-null döndüğü için hata yanlışlıkla iPhone'larda da fırlatılıyordu).

## Neden override
`kartal` 4.2.0 `share_plus: ^11.0.0`'a kilitliyor, bu yüzden normal yoldan yükseltilemiyor. **kartal kendi kısıtını yükseltince bu override kaldırılmalı** — pubspec.yaml'a not düşüldü.

## Bilinen sınırlama
kartal'ın `AppPlatform.share()` metodunda `return` eksik; iPad'de paylaşım penceresi iki kez açılıyor. Bu PR onu düzeltmiyor, kartal tarafında ele alınmalı.

## Test Edildi
- iOS: akış haber paylaş + slider mekan paylaş ✅
- Android: build alındı (AGP bump doğrulandı) + paylaşım ✅
- `dart analyze`: 0 error / 0 warning

Ref #444