### PR TITLE
Refactor home view layout and general scaffold padding

### DIFF
--- a/lib/features/main/home/view/home_view.dart
+++ b/lib/features/main/home/view/home_view.dart
@@ -54,17 +54,25 @@ class _HomeViewState extends ConsumerState<HomeView>
     super.build(context);
     return GeneralScaffold(
       key: const Key('homeView'),
+      padding: .zero,
       body: CustomScrollView(
         key: const Key('homeScrollView'),
         keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
         physics: const ClampingScrollPhysics(),
         slivers: [
           const AdvertisementSlider(),
-          const _HomeHeaderBlock(),
-          const _SearchFilterRow(),
-          const _ActiveFilterBar(),
-          const _CategoriesItems(),
-          const _HomePlaceArea(),
+          const SliverPadding(
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            sliver: SliverMainAxisGroup(
+              slivers: [
+                _HomeHeaderBlock(),
+                _SearchFilterRow(),
+                _ActiveFilterBar(),
+                _CategoriesItems(),
+                _HomePlaceArea(),
+              ],
+            ),
+          ),
           const EmptyBox.largeXxHeight().ext.sliver,
         ],
       ),
@@ -211,9 +219,9 @@ final class _CustomSearchField extends StatelessWidget {
   }
 
   OutlineInputBorder get _searchBorder => OutlineInputBorder(
-        borderRadius: BorderRadius.circular(AppRadius.md),
-        borderSide: BorderSide.none,
-      );
+    borderRadius: BorderRadius.circular(AppRadius.md),
+    borderSide: BorderSide.none,
+  );
 }
 
 final class _CategoriesItems extends ConsumerWidget {

--- a/lib/product/utility/carousel/custom_carousel_options.dart
+++ b/lib/product/utility/carousel/custom_carousel_options.dart
@@ -11,14 +11,14 @@ final class CustomCarouselOptions extends CarouselOptions {
   /// * curve: easeOut
   /// * autoPlay: true
   CustomCarouselOptions.advertisement({
-    double height = 150,
+    super.height,
+    super.viewportFraction,
     super.onPageChanged,
   }) : super(
-          autoPlayAnimationDuration: DurationConstant.durationNormal,
-          height: height,
-          autoPlayCurve: Curves.easeOut,
-          autoPlay: true,
-          padEnds: true,
-          pageSnapping: false,
-        );
+         autoPlayAnimationDuration: DurationConstant.durationNormal,
+         autoPlayCurve: Curves.easeOut,
+         autoPlay: true,
+         padEnds: true,
+         pageSnapping: false,
+       );
 }

--- a/lib/product/widget/general/general_scaffold.dart
+++ b/lib/product/widget/general/general_scaffold.dart
@@ -5,16 +5,17 @@ import 'package:life_shared/life_shared.dart';
 final class GeneralScaffold extends Scaffold {
   GeneralScaffold({
     required Widget body,
+    EdgeInsetsGeometry? padding,
     super.appBar,
     super.key,
     super.floatingActionButton,
     super.floatingActionButtonLocation,
     super.backgroundColor,
   }) : super(
-          extendBody: true,
-          body: Padding(
-            padding: const PagePadding.horizontal16Symmetric(),
-            child: body,
-          ),
-        );
+         extendBody: true,
+         body: Padding(
+           padding: padding ?? const PagePadding.horizontal16Symmetric(),
+           child: body,
+         ),
+       );
 }

--- a/lib/sub_feature/advertisement_board/views/advertisement_slider.dart
+++ b/lib/sub_feature/advertisement_board/views/advertisement_slider.dart
@@ -31,13 +31,18 @@ final class AdvertisementSlider extends ConsumerStatefulWidget {
 
 final class _AdvertisementSliderState extends ConsumerState<AdvertisementSlider>
     with _AdvertisementSliderStateMixin {
-  static const double _sliderHeight = 178;
+  static const double _aspectRatio = 16 / 9;
+  static const double _viewportFraction = 0.8;
+
   int _current = 0;
 
   @override
   Widget build(BuildContext context) {
     final items = ref.watch(advertisementBoardViewModelProvider).advertisements;
     final pageCount = items.length + 1;
+    final sliderWidth = context.sized.width * _viewportFraction;
+    final sliderHeight = sliderWidth / _aspectRatio;
+
     return SliverPadding(
       padding: const PagePadding.onlyTop(),
       sliver: SliverToBoxAdapter(
@@ -46,17 +51,18 @@ final class _AdvertisementSliderState extends ConsumerState<AdvertisementSlider>
             CarouselSlider.builder(
               itemCount: pageCount,
               itemBuilder: (context, index, realIndex) {
-                final child =
-                    index == 0 ? const _HouseAdCard() : _AdvertisementItem(
+                final child = index == 0
+                    ? const _HouseAdCard()
+                    : _AdvertisementItem(
                         items[index - 1],
                       );
                 return Padding(
-                  padding: const PagePadding.horizontalLowSymmetric(),
+                  padding: const PagePadding.horizontalLowXss(),
                   child: child,
                 );
               },
               options: CustomCarouselOptions.advertisement(
-                height: _sliderHeight,
+                height: sliderHeight,
                 onPageChanged: (index, reason) {
                   setState(() => _current = index);
                 },


### PR DESCRIPTION
## Home Layout & Advertisement Slider Improvements

This PR refactors the home view layout and advertisement slider sizing to improve consistency, flexibility, and responsiveness across different screen sizes.

### Changes

* Updated the home view to use `SliverPadding` for consistent horizontal spacing across content sections.
* Added optional padding support to `GeneralScaffold` for more flexible layout customization.
* Set the home view scaffold padding to zero and moved horizontal padding management to the sliver level.
* Updated the advertisement slider to use a responsive `16:9` aspect ratio.
* Added a `viewportFraction` of `0.8` to improve the advertisement carousel layout.
* Reworked advertisement slider height calculation based on screen width and aspect ratio.
* Adjusted advertisement item padding for improved visual balance.
* Updated `CustomCarouselOptions.advertisement` to support responsive height and viewport configuration.
* Cleaned up `CustomCarouselOptions` by using super parameters for better readability and maintainability.
* Applied minor layout and code cleanup improvements. 
 

<table>
  <tr>
    <th align="center">Before</th>
    <th align="center">After</th>
  </tr>
  <tr>
    <td align="center">
      <img
        width="200"
        alt="Edit Profile"
        src="https://github.com/user-attachments/assets/afd7b570-7a44-4f61-bc9c-f491849be5f2" 
      />
    </td>
    <td align="center">
      <img
        width="200"
        alt="Settings"
        src="https://github.com/user-attachments/assets/bbfc986b-ab98-4f5a-9598-946829f83037" 
      />
    </td>
  </tr>
</table>