### PR TITLE
fix: issue #465 — layout tasmalari ve grup silinince cikis

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -758,6 +758,7 @@
         "deleteGroupConfirmMessage": "This removes the group for all members.",
         "deleteGroupConfirmCancel": "Cancel",
         "deleteGroupSuccess": "Group deleted.",
+        "groupRemoved": "This group has been deleted.",
         "categoryLabel": "Category"
       }
     },

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -758,6 +758,7 @@
         "deleteGroupConfirmMessage": "Bu işlem grubu tüm üyeler için kaldırır.",
         "deleteGroupConfirmCancel": "Vazgeç",
         "deleteGroupSuccess": "Grup silindi.",
+        "groupRemoved": "Bu grup silindi.",
         "categoryLabel": "Kategori"
       }
     },

--- a/lib/features/community/group_detail/details/view/mixin/group_details_view_mixin.dart
+++ b/lib/features/community/group_detail/details/view/mixin/group_details_view_mixin.dart
@@ -41,11 +41,6 @@ mixin GroupDetailsViewMixin
       appProvider.showSnackbarMessage(
         LocaleKeys.message_somethingWentWrong.tr(),
       );
-      return;
     }
-    appProvider.showSnackbarMessage(
-      LocaleKeys.community_groupDetail_details_deleteGroupSuccess.tr(),
-    );
-    context.pop();
   }
 }

--- a/lib/features/community/group_detail/group_detail_view.dart
+++ b/lib/features/community/group_detail/group_detail_view.dart
@@ -1,18 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/features/community/group_detail/details/view/group_details_view.dart';
 import 'package:lifeclient/features/community/group_detail/discussions/view/group_discussions_view.dart';
+import 'package:lifeclient/features/community/group_detail/mixin/group_detail_view_mixin.dart';
 import 'package:lifeclient/features/community/group_detail/wall/view/group_wall_view.dart';
 import 'package:lifeclient/features/community/group_detail/widget/group_detail_sliver_header.dart';
 import 'package:lifeclient/product/utility/constants/app_constants.dart';
+import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
 
-final class GroupDetailView extends StatelessWidget {
+final class GroupDetailView extends ConsumerStatefulWidget {
   const GroupDetailView({required this.model, super.key});
 
   final GroupModel model;
 
   @override
+  ConsumerState<GroupDetailView> createState() => _GroupDetailViewState();
+}
+
+final class _GroupDetailViewState extends ConsumerState<GroupDetailView>
+    with AppProviderMixin<GroupDetailView>, GroupDetailViewMixin {
+  @override
   Widget build(BuildContext context) {
+    final model = widget.model;
     return Scaffold(
       body: DefaultTabController(
         length: AppConstants.kThree,

--- a/lib/features/community/group_detail/mixin/group_detail_view_mixin.dart
+++ b/lib/features/community/group_detail/mixin/group_detail_view_mixin.dart
@@ -1,0 +1,30 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:lifeclient/features/community/group_detail/group_detail_view.dart';
+import 'package:lifeclient/features/community/group_detail/provider/group_detail_state.dart';
+import 'package:lifeclient/features/community/group_detail/provider/group_detail_view_model.dart';
+import 'package:lifeclient/product/init/language/locale_keys.g.dart';
+import 'package:lifeclient/product/utility/mixin/app_provider_mixin.dart';
+
+mixin GroupDetailViewMixin
+    on ConsumerState<GroupDetailView>, AppProviderMixin<GroupDetailView> {
+  @override
+  void initState() {
+    super.initState();
+    ref.listenManual(
+      groupDetailViewModelProvider(widget.model.id),
+      _onGroupChanged,
+    );
+  }
+
+  void _onGroupChanged(GroupDetailState? previous, GroupDetailState next) {
+    if (next.group?.isDeleted != true) return;
+    if (!mounted || !context.canPop()) return;
+
+    context.pop();
+    appProvider.showSnackbarMessage(
+      LocaleKeys.community_groupDetail_details_groupRemoved.tr(),
+    );
+  }
+}

--- a/lib/product/widget/card/general_place_card.dart
+++ b/lib/product/widget/card/general_place_card.dart
@@ -42,8 +42,7 @@ final class GeneralPlaceCard extends StatelessWidget {
         ),
         child: ClipRRect(
           borderRadius: BorderRadius.circular(AppRadius.lg),
-          child: SizedBox(
-            height: context.sized.dynamicHeight(0.12) + WidgetSizes.spacingM,
+          child: IntrinsicHeight(
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
@@ -74,9 +73,10 @@ final class _PlaceImageBlock extends StatelessWidget {
       return _MosaicPlaceholder(accent: accent, category: model.category);
     }
     return Stack(
-      fit: StackFit.expand,
       children: [
-        CustomNetworkImage(imageUrl: image, fit: BoxFit.cover),
+        Positioned.fill(
+          child: CustomNetworkImage(imageUrl: image, fit: BoxFit.cover),
+        ),
         Positioned(
           left: AppSpacing.xs,
           bottom: AppSpacing.xs,

--- a/lib/product/widget/general/dotted/general_dotted_photo_add.dart
+++ b/lib/product/widget/general/dotted/general_dotted_photo_add.dart
@@ -50,9 +50,14 @@ class _GeneralDottedPhotoAddState extends State<GeneralDottedPhotoAdd> {
                       .selectAndUpdatePhotoFromMediaSheet
                 : null,
             child: GeneralDottedRectangle(
-              child: SizedBox(
-                height: context.sized.dynamicHeight(
-                  file != null ? .3 : .15,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: context.sized.dynamicHeight(
+                    file != null ? .3 : .15,
+                  ),
+                  maxHeight: file != null
+                      ? context.sized.dynamicHeight(.3)
+                      : double.infinity,
                 ),
                 child: Center(
                   child: _BodyImage(file: file),
@@ -115,8 +120,7 @@ final class _ImageTypeContainer extends StatelessWidget {
         await context.generalDottedPhotoAddContext
             .selectAndUpdatePhotoByPhotoPickType(_photoPickType);
       },
-      child: Container(
-        width: context.sized.dynamicWidth(.25),
+      child: DecoratedBox(
         decoration: const BoxDecoration(
           borderRadius: CustomRadius.large,
         ),
@@ -142,18 +146,23 @@ final class _ImageTypeIconAndText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         Icon(
           _icon,
           color: context.general.colorScheme.onSecondaryFixed,
         ),
         const EmptyBox.smallWidth(),
-        Text(
-          _text,
-          textAlign: TextAlign.start,
-          style: context.general.textTheme.labelMedium?.copyWith(
-            color: context.general.colorScheme.onSecondaryFixed,
-            fontWeight: FontWeight.w400,
+        Flexible(
+          child: Text(
+            _text,
+            textAlign: TextAlign.start,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: context.general.textTheme.labelMedium?.copyWith(
+              color: context.general.colorScheme.onSecondaryFixed,
+              fontWeight: FontWeight.w400,
+            ),
           ),
         ),
       ],

--- a/lib/product/widget/general/general_button.dart
+++ b/lib/product/widget/general/general_button.dart
@@ -168,12 +168,31 @@ class _Child extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
-      builder: (context, constraints) =>
-          _buildRow(context, canFlex: constraints.hasBoundedWidth),
+      builder: (context, constraints) => _ChildRow(
+        label: label,
+        icon: icon,
+        iconAlignment: iconAlignment,
+        canFlex: constraints.hasBoundedWidth,
+      ),
     );
   }
+}
 
-  Widget _buildRow(BuildContext context, {required bool canFlex}) {
+final class _ChildRow extends StatelessWidget {
+  const _ChildRow({
+    required this.label,
+    required this.canFlex,
+    this.icon,
+    this.iconAlignment,
+  });
+
+  final String label;
+  final bool canFlex;
+  final IconData? icon;
+  final IconAlignment? iconAlignment;
+
+  @override
+  Widget build(BuildContext context) {
     final contentColor = context.general.colorScheme.surface;
 
     final text = Text(

--- a/lib/product/widget/general/general_button.dart
+++ b/lib/product/widget/general/general_button.dart
@@ -167,21 +167,30 @@ class _Child extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) =>
+          _buildRow(context, canFlex: constraints.hasBoundedWidth),
+    );
+  }
+
+  Widget _buildRow(BuildContext context, {required bool canFlex}) {
     final contentColor = context.general.colorScheme.surface;
 
-    final labelWidget = Flexible(
-      child: Text(
-        label,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: context.general.textTheme.titleMedium?.copyWith(
-          color: contentColor,
-          fontWeight: FontWeight.w900,
-        ),
+    final text = Text(
+      label,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: context.general.textTheme.titleMedium?.copyWith(
+        color: contentColor,
+        fontWeight: FontWeight.w900,
       ),
     );
+    final labelWidget = canFlex ? Flexible(child: text) : text;
+    final mainAxisSize = canFlex ? MainAxisSize.max : MainAxisSize.min;
+
     if (icon == null) {
       return Row(
+        mainAxisSize: mainAxisSize,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [labelWidget],
       );
@@ -189,6 +198,7 @@ class _Child extends StatelessWidget {
     final iconWidget = Icon(icon, color: contentColor);
     final alignment = iconAlignment ?? IconAlignment.start;
     return Row(
+      mainAxisSize: mainAxisSize,
       mainAxisAlignment: MainAxisAlignment.center,
       children: switch (alignment) {
         IconAlignment.start => [


### PR DESCRIPTION
Issue #465'teki su maddeleri kapatiyor:

- [x] Resim yukleme alaninda size hatasi
- [x] Mekanlarda kategori ve card size hatasi
- [x] Akistan grup kaldirilinca aninda yansimiyor

Ayrica issue'da yazmayan, test sirasinda cikan bir regresyon da dahil (asagida).

---

## 1. Fotograf yukleme alani — 3.2px tasma

**Nerede:** Yeni Isletme Talebi, Yeni Proje Talebi

Kamera ve Galeri butonlarinin her birine `width: dynamicWidth(.25)` verilmis. Icindeki `Icon + bosluk + metin` ekranin %25'ine sigmiyor.

| | Once | Sonra |
|---|---|---|
| Buton genisligi | `Container(width: dynamicWidth(.25))` | `DecoratedBox` — icerige gore |
| Ic Row | varsayilan `max` | `mainAxisSize: min` + metin `Flexible` + ellipsis |
| Dis kutu | `SizedBox(height:)` | `ConstrainedBox(minHeight/maxHeight)` |

Ucuncusu: onizlemede yukseklik aynen sabit kaliyor, bos halde alt sinir oluyor ki buyuk metin olceginde dikey tasma da olmasin.

## 2. Mekan liste karti — 1.6px tasma + shimmer ziplamasi

**Nerede:** Ana sayfa → Mekanlar (liste gorunumu)

Iki asamali. Once `SizedBox(height: dynamicHeight(0.12) + spacingM)` → `IntrinsicHeight` yapildi, tasma gitti. Ama bu kez yeni bir sorun cikti: `CustomNetworkImage`'in placeholder'i `height: WidgetSizes.spacingXxl12 * 2` = **200px** sabit istiyor. Yukleme sirasinda kart 200px, gorsel gelince ~130px'e dusuyordu.

Cozum: `Stack`'in gorsel cocugu `Positioned.fill` yapildi. `Positioned` cocuklar Stack'in intrinsic yuksekligine katilmaz, boylece karti `_Body` boyutlandiriyor. Ayrica `Positioned.fill` gorsele tight constraint verdigi icin placeholder'in hatali `width: context.sized.width` (tum ekran) degeri de etkisiz kaliyor.

`custom_network_image.dart`'a dokunulmadi — 29 dosya kullaniyor, sadece 3'u kendi placeholder'ini geciriyor. Oradaki placeholder gercekten hatali (`width` her cagri yerinde yanlis) ama duzeltmek 26 ekran testi gerektirir, ayri is.

**Not:** Grid gorunumu kontrol edildi, tasma yok. `mainAxisExtent: 0.24` yeterli, degisiklik gerekmedi.

## 3. GeneralButtonV2 — RenderFlex assert (regresyon, issue'da yok)

**Nerede:** Yeni Burs Talebi acilinca

```
RenderFlex children have non-zero flex but incoming width constraints are unbounded.
general_button.dart:184
```

**Kok sebep:** `cab146d1` (PR #459) buton etiketini ellipsis icin `Flexible` ile sarmis. Burs formunda buton `upload_file_section_v2.dart`'taki Row'un flex'siz cocugu → sinirsiz genislik aliyor. Flutter'in assert kosulu:

```dart
if (!canFlex && (mainAxisSize == MainAxisSize.max || fit == FlexFit.tight))
```

`Flexible` zaten `loose`; tetikleyen `mainAxisSize == max`'ti.

**Cozum:** `LayoutBuilder` ile genislige bakiliyor.

| Genislik | mainAxisSize | Etiket |
|---|---|---|
| Sinirli (normal butonlar) | `max` | `Flexible` — mevcut davranisla birebir ayni |
| Sinirsiz | `min` | duz `Text` — daraliyor, assert yok |

Ilk denemede duz `MainAxisSize.min` yapilmisti, tam genislik butonlari daralttigi icin geri alindi. Bu buton 27 dosyada kullaniliyor.

## 4. Grup silinince kullaniciyi disari cikar

**Nerede:** Akis → Gruplar → grup detayi

Grup dokumani `group_detail_view_model.dart:18`'de zaten `snapshots().listen` ile canli dinleniyordu, ama `isDeleted` state'e dusunce kimse tepki vermiyordu. Yeni mixin bunu izleyip sayfayi kapatiyor — yonetici silince iceride olan diger uyeler de aninda cikiyor.

`deleteGroup`'taki `context.pop()` ve basari mesaji kaldirildi: ikisi de ayni anda calisinca hangi mesajin gorunecegi Firestore snapshot zamanlamasina bagli kaliyordu. Cikis artik tek yerden yonetiliyor.

**Liste tarafina dokunulmadi.** `FirestoreQueryBuilder` `snapshots().listen` kullaniyor ve `groupsQuery` `isDeleted == false` filtreliyor, yani liste kendiliginden guncelleniyor.

**Kapsam disi:** Silinmis gruba yazmayi engellemek icin Firestore rules gerekir; rules bu repoda degil (life_admin). Bu PR kullaniciyi disari cikariyor, yazma yolunu rules seviyesinde kapatmiyor.

---

## Test

- Yeni Isletme + Yeni Proje talebi → fotograf alaninda tasma yok
- Ana sayfa mekan listesi → tasma yok, shimmer sirasinda kart ziplamiyor
- Ana sayfa grid gorunumu → sorun yok
- Yeni Burs talebi → assert yok
- Normal butonlar → tam genislik korunuyor
- `flutter analyze` → yeni issue yok