### PR TITLE
fix(place-detail): hide comments tab and button when comments are disabled

### DIFF
--- a/lib/features/place_detail/view/place_detail_view.dart
+++ b/lib/features/place_detail/view/place_detail_view.dart
@@ -37,7 +37,19 @@ part 'widget/tabs/place_detail_about.dart';
 part 'widget/tabs/place_detail_comments.dart';
 part 'widget/tabs/place_detail_showcase.dart';
 
-enum _PlaceDetailTab { about, comments }
+enum _PlaceDetailTab {
+  about(LocaleKeys.placeDetailView_tabAbout),
+  comments(LocaleKeys.placeDetailView_tabComments);
+
+  const _PlaceDetailTab(this.labelKey);
+
+  final String labelKey;
+
+  static List<_PlaceDetailTab> visibleFor(StoreModel store) => [
+    about,
+    if (store.isCommentEnabled) comments,
+  ];
+}
 
 final class PlaceDetailView extends ConsumerStatefulWidget {
   const PlaceDetailView({required this.store, required this.id, super.key});
@@ -70,8 +82,10 @@ final class _PlaceDetailViewState extends ConsumerState<PlaceDetailView>
       );
     }
 
+    final tabs = _PlaceDetailTab.visibleFor(store);
+
     return DefaultTabController(
-      length: _PlaceDetailTab.values.length,
+      length: tabs.length,
       child: MosaicCollapsingPage(
         showLoeading: true,
 
@@ -80,14 +94,17 @@ final class _PlaceDetailViewState extends ConsumerState<PlaceDetailView>
           onCall: onCall,
           onComment: onComment,
         ),
-        pinnedHeader: const PlaceDetailTabBar(),
+        pinnedHeader: tabs.length > AppConstants.kOne
+            ? _PlaceDetailTabBar(tabs: tabs)
+            : null,
 
         slivers: [
           SliverPadding(
             padding: const PagePadding.generalAllLow(),
             sliver: SliverToBoxAdapter(
-              child: PlaceDetailTabContent(
+              child: _PlaceDetailTabContent(
                 store: store,
+                tabs: tabs,
                 onCall: onCall,
                 onCopyAddress: onCopyAddress,
                 onOpenMaps: onOpenMaps,

--- a/lib/features/place_detail/view/widget/place_detail_tab_bar.dart
+++ b/lib/features/place_detail/view/widget/place_detail_tab_bar.dart
@@ -1,7 +1,9 @@
 part of '../place_detail_view.dart';
 
-final class PlaceDetailTabBar extends StatelessWidget {
-  const PlaceDetailTabBar({super.key});
+final class _PlaceDetailTabBar extends StatelessWidget {
+  const _PlaceDetailTabBar({required this.tabs});
+
+  final List<_PlaceDetailTab> tabs;
 
   @override
   Widget build(BuildContext context) {
@@ -17,8 +19,7 @@ final class PlaceDetailTabBar extends StatelessWidget {
           fontWeight: FontWeight.normal,
         ),
         tabs: [
-          Tab(text: LocaleKeys.placeDetailView_tabAbout.tr()),
-          Tab(text: LocaleKeys.placeDetailView_tabComments.tr()),
+          for (final tab in tabs) Tab(text: tab.labelKey.tr()),
         ],
       ),
     );

--- a/lib/features/place_detail/view/widget/place_detail_tab_content.dart
+++ b/lib/features/place_detail/view/widget/place_detail_tab_content.dart
@@ -1,15 +1,16 @@
 part of '../place_detail_view.dart';
 
-final class PlaceDetailTabContent extends StatelessWidget {
-  const PlaceDetailTabContent({
+final class _PlaceDetailTabContent extends StatelessWidget {
+  const _PlaceDetailTabContent({
     required this.store,
+    required this.tabs,
     required this.onCall,
     required this.onCopyAddress,
     required this.onOpenMaps,
-    super.key,
   });
 
   final StoreModel store;
+  final List<_PlaceDetailTab> tabs;
   final VoidCallback onCall;
   final VoidCallback onCopyAddress;
   final Future<void> Function(GeoPoint latLong) onOpenMaps;
@@ -21,7 +22,7 @@ final class PlaceDetailTabContent extends StatelessWidget {
     return ListenableBuilder(
       listenable: tabController,
       builder: (context, child) {
-        return switch (_PlaceDetailTab.values[tabController.index]) {
+        return switch (tabs[tabController.index]) {
           _PlaceDetailTab.about => PlaceDetailAboutTab(
             store: store,
             onCall: onCall,

--- a/lib/features/place_detail/view/widget/place_summary_card.dart
+++ b/lib/features/place_detail/view/widget/place_summary_card.dart
@@ -139,6 +139,10 @@ final class _SummaryActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (!store.hasPhone && !store.isCommentEnabled) {
+      return const SizedBox.shrink();
+    }
+
     return Row(
       spacing: AppSpacing.xs,
       children: [
@@ -155,19 +159,20 @@ final class _SummaryActions extends StatelessWidget {
               ),
             ),
           ),
-        Expanded(
-          child: CustomBounceable(
-            child: ElevatedButton.icon(
-              onPressed: onComment,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.coral100,
-                foregroundColor: AppColors.coral700,
+        if (store.isCommentEnabled)
+          Expanded(
+            child: CustomBounceable(
+              child: ElevatedButton.icon(
+                onPressed: onComment,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.coral100,
+                  foregroundColor: AppColors.coral700,
+                ),
+                label: Text(LocaleKeys.placeDetailView_makeComment.tr()),
+                icon: const Icon(AppIcons.comment),
               ),
-              label: Text(LocaleKeys.placeDetailView_makeComment.tr()),
-              icon: const Icon(AppIcons.comment),
             ),
           ),
-        ),
       ],
     );
   }

--- a/lib/features/place_detail/view/widget/place_summary_card.dart
+++ b/lib/features/place_detail/view/widget/place_summary_card.dart
@@ -23,7 +23,7 @@ final class PlaceSummaryCard extends ConsumerWidget with AppProviderStateMixin {
       children: [
         _SummaryHeader(store: store, town: town),
         StatusPill(store: store),
-        _SummaryRatingRow(store: store),
+        if (store.isCommentEnabled) _SummaryRatingRow(store: store),
         _SummaryActions(store: store, onCall: onCall, onComment: onComment),
       ],
     );

--- a/lib/product/widget/card/general_place_card.dart
+++ b/lib/product/widget/card/general_place_card.dart
@@ -209,11 +209,13 @@ class _Body extends ConsumerWidget with AppProviderStateMixin {
           const EmptyBox.xxSmallHeight(),
           Row(
             children: [
-              PlaceRatingLabel(
-                rating: model.averageRatingLabel,
-                reviewCount: model.ratingCount,
-              ),
-              const SizedBox(width: AppSpacing.sm),
+              if (model.isCommentEnabled) ...[
+                PlaceRatingLabel(
+                  rating: model.averageRatingLabel,
+                  reviewCount: model.ratingCount,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+              ],
               Flexible(
                 child: GeneralContentSmallTitle(
                   value: distanceLabel,

--- a/lib/product/widget/card/place/general_place_grid_card.dart
+++ b/lib/product/widget/card/place/general_place_grid_card.dart
@@ -205,12 +205,14 @@ class _GridBody extends ConsumerWidget with AppProviderStateMixin {
               ),
             ],
           ),
-          const EmptyBox.xSmallHeight(),
-          PlaceRatingLabel(
-            rating: model.averageRatingLabel,
-            reviewCount: model.ratingCount,
-            iconSize: IconSize.smallX.value,
-          ),
+          if (model.isCommentEnabled) ...[
+            const EmptyBox.xSmallHeight(),
+            PlaceRatingLabel(
+              rating: model.averageRatingLabel,
+              reviewCount: model.ratingCount,
+              iconSize: IconSize.smallX.value,
+            ),
+          ],
         ],
       ),
     );


### PR DESCRIPTION
## Problem

A place with `isCommentEnabled: false` still showed the **Yorumlar** tab and the **Yorum Yap** button. Opening that tab showed a blank page.

The blank page was the giveaway: `RateCommentListView` already honours the flag and returns `SizedBox.shrink()` when comments are off, so the content was correctly hidden — but the tab itself and the button never learned about the flag. The gating was only half wired up.

## Fix

The visible tab list is derived from the store in a single place:

```dart
enum _PlaceDetailTab {
  about(LocaleKeys.placeDetailView_tabAbout),
  comments(LocaleKeys.placeDetailView_tabComments);

  static List<_PlaceDetailTab> visibleFor(StoreModel store) => [
    about,
    if (store.isCommentEnabled) comments,
  ];
}
```

That list feeds all three consumers — `DefaultTabController.length`, the tab bar, and the tab content — so the tab index cannot drift out of sync with what is rendered. Previously all three read `_PlaceDetailTab.values` independently; hiding a tab in only one of them would have produced a `RangeError` or the wrong tab body.

Two follow-on cases, both agreed with @muhammedeminalan beforehand:

- **Only one tab left** — the tab bar is dropped entirely rather than rendering a pointless single-tab bar. `MosaicCollapsingPage.pinnedHeader` is already nullable, so this needed no extra wrapper.
- **Neither phone nor comments** — the whole action row is removed instead of leaving an empty `Row`.

## Naming change worth a look

`PlaceDetailTabBar` and `PlaceDetailTabContent` are now `_PlaceDetailTabBar` and `_PlaceDetailTabContent`.

They take the private `_PlaceDetailTab` enum in their constructors, which the analyzer flags as `library_private_types_in_public_api`. Making them private is the smaller change: both are `part` files of `place_detail_view.dart`, neither is referenced anywhere outside that library, and the rest of the part widgets in this feature are already private. The alternative was making the enum public and leaking it out of the feature for no caller.

## Known limitation

`_PlaceDetailTabContent` reads `tabs[tabController.index]`. If `isCommentEnabled` flipped from `true` to `false` while the screen was open and the Comments tab was selected, the index could outlive the list for one frame and throw.

This is not reachable today — verified all three paths that touch the store:

- `_fetchStoreModel` is one-shot, not a stream
- `applyRatingDelta` only changes rating fields and preserves the flag through `copyWith`
- `retry()` sets `isFetching: true` first, which swaps the whole subtree for the shimmer and tears down the `DefaultTabController`

It would become reachable if the store is ever switched to a live `snapshots()` listener. A one-line `index.clamp(0, tabs.length - 1)` closes it; left out of this PR to keep the diff to the reported bug.

## Test

Verified against the local Firestore emulator by flipping `isCommentEnabled` on a real store:

- **Comments off** — no Yorum Yap button, no Yorumlar tab, no tab bar at all, Hakkında renders directly
- **Comments on** — unchanged, two tabs and two buttons
- `flutter analyze` — clean
- `dart format` — no changes

Not verified on device: the *no phone **and** no comments* case, which hides the entire action row. The code path is a single `if`, but calling it out.