### PR TITLE
fix(onboarding): leave the app on back instead of a frozen splash

### DIFF
--- a/lib/features/splash/splash_view_mixin.dart
+++ b/lib/features/splash/splash_view_mixin.dart
@@ -65,7 +65,7 @@ mixin SplashViewMixin
       }
 
       if (next.isNeedToOnBoard) {
-        const OnboardRoute().pushReplacement(context);
+        const OnboardRoute().go(context);
         return;
       }
       if (next.isNeedToForceUpdate) {

--- a/lib/product/navigation/app_router.dart
+++ b/lib/product/navigation/app_router.dart
@@ -50,9 +50,6 @@ part 'merchant_guard.dart';
 @TypedGoRoute<SplashRoute>(
   path: '/',
   name: SplashRoute.routeName,
-  routes: [
-    OnboardRoute.route,
-  ],
 )
 final class SplashRoute extends GoRouteData with $SplashRoute {
   const SplashRoute();
@@ -601,13 +598,9 @@ final class DiscussionDetailRoute extends GoRouteData
       DiscussionDetailView(args: $extra);
 }
 
+@TypedGoRoute<OnboardRoute>(path: '/onboard', name: 'Onboard')
 final class OnboardRoute extends GoRouteData with $OnboardRoute {
   const OnboardRoute();
-
-  static const route = TypedGoRoute<OnboardRoute>(
-    path: 'onboard',
-    name: 'Onboard',
-  );
 
   @override
   Page<void> buildPage(BuildContext context, GoRouterState state) {


### PR DESCRIPTION
## Problem

On a fresh install, pressing the Android back button anywhere in the onboarding slider leaves the app on the splash screen with a frozen loading animation and no way forward.

## Cause

`OnboardRoute` was declared inside `SplashRoute`'s `routes:` list, so navigating to `/onboard` built a two page stack — `[Splash, Onboard]` — with the splash screen still alive underneath. Back popped the onboarding away and revealed that splash, which by then had:

- finished `SplashViewModel._controlApplication()`
- fired its one-shot `ref.listenManual` callback, so no further state change can redirect
- called `_controller.stop()`, freezing the lottie

The result reads as "still loading" but nothing is pending. `pushReplacement` did not help, because the extra page comes from the route's position in the tree, not from how it was pushed.

## Fix

Declare `OnboardRoute` at the top level and navigate with `go`, so the stack holds onboarding alone and back exits the app. This also matches the convention in CLAUDE.md that `push`/`pushReplacement` are only for guard-free temporary overlays.

## Compatibility

The location is unchanged — a child path `onboard` under `/` already resolved to `/onboard` — so deep links are unaffected, and the route name `'Onboard'` stays the same for analytics.

## Testing

Android, on a fresh install or after clearing app data:

1. Launch the app so the onboarding slider appears
2. Press the back button on any slider step — the app should exit rather than showing a frozen splash
3. Relaunch — onboarding should start over, since it was never completed
4. Complete onboarding — the login screen appears, and back exits the app there too

iOS has no back button, so the bug never reproduced there.