### PR TITLE
fix(ui): let GeneralButtonV2 be measured for intrinsic size

### DIFF
--- a/lib/product/package/file_picker/upload_file_section_v2.dart
+++ b/lib/product/package/file_picker/upload_file_section_v2.dart
@@ -128,6 +128,7 @@ final class _UploadButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return GeneralButtonV2.async(
       isBorderless: true,
+      shrinkWrap: true,
       action: uploadPressed,
       label: isFileNotNull
           ? LocaleKeys.fileUpload_update.tr()

--- a/lib/product/widget/general/general_button.dart
+++ b/lib/product/widget/general/general_button.dart
@@ -33,6 +33,7 @@ final class GeneralButtonV2 extends StatefulWidget {
     required String label,
     bool isEnabled = true,
     bool isBorderless = false,
+    bool shrinkWrap = false,
     IconData? icon,
     IconAlignment? iconAlignment,
     Color? backgroundColor,
@@ -45,6 +46,7 @@ final class GeneralButtonV2 extends StatefulWidget {
       isEnabled: isEnabled,
       buttonPadding: buttonPadding,
       isBorderless: isBorderless,
+      shrinkWrap: shrinkWrap,
       icon: icon,
       iconAlignment: iconAlignment,
       backgroundColor: backgroundColor,
@@ -56,6 +58,7 @@ final class GeneralButtonV2 extends StatefulWidget {
     required String label,
     bool isEnabled = true,
     bool isBorderless = false,
+    bool shrinkWrap = false,
     IconData? icon,
     IconAlignment? iconAlignment,
     Color? backgroundColor,
@@ -68,6 +71,7 @@ final class GeneralButtonV2 extends StatefulWidget {
       isEnabled: isEnabled,
       buttonPadding: buttonPadding,
       isBorderless: isBorderless,
+      shrinkWrap: shrinkWrap,
       icon: icon,
       iconAlignment: iconAlignment,
       backgroundColor: backgroundColor,
@@ -79,6 +83,7 @@ final class GeneralButtonV2 extends StatefulWidget {
     required this.isAsync,
     this.isEnabled = true,
     this.isBorderless = false,
+    this.shrinkWrap = false,
     this.icon,
     this.iconAlignment,
     this.backgroundColor,
@@ -90,6 +95,7 @@ final class GeneralButtonV2 extends StatefulWidget {
   final bool isAsync;
   final bool isEnabled;
   final bool isBorderless;
+  final bool shrinkWrap;
   final IconData? icon;
   final IconAlignment? iconAlignment;
   final Color? backgroundColor;
@@ -128,8 +134,9 @@ final class _GeneralButtonV2State extends State<GeneralButtonV2> {
             valueListenable: _isLoading,
             builder: (context, value, _) {
               if (!value) {
-                return _Child(
+                return _ChildRow(
                   label: widget.label,
+                  canFlex: !widget.shrinkWrap,
                   icon: widget.icon,
                   iconAlignment: widget.iconAlignment,
                 );
@@ -151,30 +158,6 @@ final class _GeneralButtonV2State extends State<GeneralButtonV2> {
 
   void _changeLoading() {
     _isLoading.value = !_isLoading.value;
-  }
-}
-
-class _Child extends StatelessWidget {
-  const _Child({
-    required this.label,
-    this.icon,
-    this.iconAlignment,
-  });
-
-  final String label;
-  final IconData? icon;
-  final IconAlignment? iconAlignment;
-
-  @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) => _ChildRow(
-        label: label,
-        icon: icon,
-        iconAlignment: iconAlignment,
-        canFlex: constraints.hasBoundedWidth,
-      ),
-    );
   }
 }
 


### PR DESCRIPTION
Closes #481

## The problem

`19db9fee` wrapped the button's label row in a `LayoutBuilder` so it could branch on whether the incoming width was bounded:

```dart
return LayoutBuilder(
  builder: (context, constraints) => _ChildRow(
    ...,
    canFlex: constraints.hasBoundedWidth,
  ),
);
```

`LayoutBuilder` cannot answer intrinsic-size queries — resolving the builder would mean running the layout callback speculatively — so any ancestor that measures intrinsics throws as soon as a `GeneralButtonV2` appears in its subtree.

Two screens were broken on `main`:

- **Merchant application** — the Back/Next bar is wrapped in `IntrinsicHeight` to keep both buttons the same height. Crashes every time the screen opens.
- **Favorites, empty state** — `SliverFillRemaining(hasScrollBody: false)` measures its child's intrinsic height, and the empty view holds a "Mekanları keşfet" button. Adding one favourite made the screen work again, because the non-empty branch returns `SliverGrid`/`SliverList`, which never ask for intrinsics.

Structurally exposed but not yet reported: `firestore_list_view`, `firestore_sliver_list_view` and `firestore_grid_view` all render their loading / error / empty states inside `SliverFillRemaining`, so any screen using them with a button in those states would have failed the same way.

In release the assertion is skipped, `LayoutBuilder` reports an intrinsic height of `0`, and the button is laid out at the wrong size — so this was never debug-only.

## The fix

Drop the `LayoutBuilder` and let the caller state the intent instead, with a `shrinkWrap` flag:

- `shrinkWrap: false` (default) — `Flexible` + `MainAxisSize.max`, the stretch-to-fill layout every current call site already relies on. Rendering is unchanged.
- `shrinkWrap: true` — plain `Text` + `MainAxisSize.min`, for callers that place the button where the width is unbounded.

One caller needs it today: the file upload section. Its button is a non-flex child of a `Row`, and a non-flex child always receives unbounded width regardless of the `Row`'s own constraints.

## Why a flag rather than a smarter widget

Boundedness cannot be determined without either a `LayoutBuilder` (which is what broke intrinsics) or a custom `RenderObject`. It also cannot be audited statically: the button is usually nested inside another widget, far from the `Row` that lays it out — the upload button lives in `_UploadButton`, several widgets away from its `Row`.

The flag makes the requirement visible at the call site. A caller that gets it wrong now hits the standard `RenderFlex ... unbounded` assert, which names the exact widget, instead of silently laying out at the wrong size.

Note: the screen `19db9fee` set out to fix (`general_dotted_photo_add.dart`) does not use `GeneralButtonV2` at all. That commit's other two changes — the dotted rectangle constraints and the place-card image — are what fixed #465, and they are untouched here.

## Verified

- `dart analyze lib` — no issues
- Merchant application opens; Back/Next render at equal height
- Favorites empty state renders with its CTA button
- File upload section renders; the "Yükle" button hugs its label
- Full-width, icon and side-by-side buttons unchanged
