### PR TITLE
fix: re-land place rating, merchant application camera & loading, memories page

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -333,7 +333,8 @@
       "institutionsDescription": "Municipality · hospital · school · cargo",
       "marketsDescription": "Palladium · Serinyol · Defne · Samandağ",
       "touristDescription": "Titus Tunnel · museums · ancient cities",
-      "linksDescription": "Emergency lines · local producers · e-government"
+      "linksDescription": "Emergency lines · local producers · e-government",
+      "memoriesDescription": "Old photos · memories · the city's archive"
     }
   },
   "projectRequest": {

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -797,6 +797,7 @@
       "visitCount": "Views",
       "reviewCount": "Reviews",
       "averageScore": "Rating",
+      "emptyValue": "—",
       "manageTitle": "Manage",
       "manageReviews": "Manage reviews",
       "manageReviewsSubtitle": "Some reviews are waiting for a reply",

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -797,6 +797,7 @@
       "visitCount": "Görüntülenme",
       "reviewCount": "Yorum",
       "averageScore": "Puan",
+      "emptyValue": "—",
       "manageTitle": "Yönet",
       "manageReviews": "Yorumları yönet",
       "manageReviewsSubtitle": "Yanıt bekleyen yorumlar var",

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -333,7 +333,8 @@
       "institutionsDescription": "Belediye · hastane · okul · kargo",
       "marketsDescription": "Palladium · Serinyol · Defne · Samandağ",
       "touristDescription": "Titus Tüneli · müzeler · antik kentler",
-      "linksDescription": "Acil hatlar · yerel üreticiler · e-devlet"
+      "linksDescription": "Acil hatlar · yerel üreticiler · e-devlet",
+      "memoriesDescription": "Eski fotoğraflar · anılar · şehrin hafızası"
     }
   },
   "projectRequest": {

--- a/lib/features/main/history/history_view.dart
+++ b/lib/features/main/history/history_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kartal/kartal.dart';
 import 'package:life_shared/life_shared.dart';
 import 'package:lifeclient/core/dependency/project_dependency_mixin.dart';
+import 'package:lifeclient/core/theme/app_context_colors.dart';
 import 'package:lifeclient/features/main/history/history_view_mixin.dart';
 import 'package:lifeclient/features/main/history/provider/history_view_model.dart';
 import 'package:lifeclient/features/main/history/widget/history_favorite_view.dart';
@@ -14,6 +15,7 @@ import 'package:lifeclient/product/package/image/custom_network_image.dart';
 import 'package:lifeclient/product/utility/constants/app_icon_sizes.dart';
 import 'package:lifeclient/product/utility/constants/app_icons.dart';
 import 'package:lifeclient/product/utility/decorations/custom_radius.dart';
+import 'package:lifeclient/product/widget/app_bar/discover_section_app_bar.dart';
 import 'package:lifeclient/product/widget/builder/firestore_grid_view.dart';
 import 'package:lifeclient/product/widget/general/general_not_found_widget.dart';
 import 'package:lifeclient/product/widget/general/index.dart';
@@ -32,29 +34,29 @@ class _HistoryViewState extends ConsumerState<HistoryView>
   @override
   Widget build(BuildContext context) {
     return GeneralScaffold(
+      appBar: DiscoverSectionAppBar(
+        title: LocaleKeys.navigationTabs_memories,
+        subtitle: LocaleKeys.navigationTabs_exploreMenu_memoriesDescription
+            .tr(),
+        accentColor: context.appColors.gold,
+      ),
       body: const _HistoryGridBuilder(),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endDocked,
-      floatingActionButton: Padding(
-        padding: const EdgeInsets.only(
-          bottom: AppIconSizes.xLarge * 2.5,
-        ),
-        child: Column(
-          spacing: AppIconSizes.smallX,
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            FloatingActionButton(
-              heroTag: HeroTags.memoryFavorite.name,
-              onPressed: () =>
-                  context.route.navigateToPage(const HistoryFavoriteSheet()),
-              child: const Icon(AppIcons.favorite),
-            ),
-            FloatingActionButton(
-              onPressed: openGoogleForm,
-              child: const Icon(Icons.add_a_photo_outlined),
-            ),
-          ],
-        ),
+      floatingActionButton: Column(
+        spacing: AppIconSizes.smallX,
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          FloatingActionButton(
+            heroTag: HeroTags.memoryFavorite.name,
+            onPressed: () =>
+                context.route.navigateToPage(const HistoryFavoriteSheet()),
+            child: const Icon(AppIcons.favorite),
+          ),
+          FloatingActionButton(
+            onPressed: openGoogleForm,
+            child: const Icon(Icons.add_a_photo_outlined),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/merchant_panel/view/sub_view/merchant_dashboard_sub_view.dart
+++ b/lib/features/merchant_panel/view/sub_view/merchant_dashboard_sub_view.dart
@@ -13,6 +13,7 @@ import 'package:lifeclient/product/utility/constants/app_constants.dart';
 import 'package:lifeclient/product/utility/constants/app_icon_sizes.dart';
 import 'package:lifeclient/product/utility/constants/app_icons.dart';
 import 'package:lifeclient/product/utility/decorations/empty_box.dart';
+import 'package:lifeclient/product/utility/extension/store_etension.dart';
 import 'package:lifeclient/product/widget/menu/content_menu.dart';
 
 part 'widget/merchant_stat_card.dart';
@@ -27,6 +28,8 @@ final class MerchantDashboardSubView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final store = state.store;
+
     return Padding(
       padding:
           const PagePadding.horizontalNormalSymmetric() +
@@ -52,7 +55,9 @@ final class MerchantDashboardSubView extends StatelessWidget {
               Expanded(
                 child: _MerchantStatCard(
                   icon: AppIcons.rate,
-                  value: state.store?.averageRatingLabel ?? '0',
+                  value: store != null && store.hasRating
+                      ? store.averageRatingLabel
+                      : LocaleKeys.merchantPanel_dashboard_emptyValue.tr(),
                   label: LocaleKeys.merchantPanel_dashboard_averageScore.tr(),
                 ),
               ),

--- a/lib/features/merchant_panel/view/widget/merchant_panel_header.dart
+++ b/lib/features/merchant_panel/view/widget/merchant_panel_header.dart
@@ -56,7 +56,6 @@ final class MerchantPanelHeader extends StatelessWidget {
             ),
           ),
         ),
-        
       ],
     );
   }
@@ -136,20 +135,21 @@ final class _MerchantPanelStoreInfo extends StatelessWidget {
                       color: context.appColors.navy500,
                     ),
                   ),
-                Row(
-                  spacing: AppSpacing.xxs,
-                  children: [
-                    Icon(
-                      AppIcons.star,
-                      size: AppIconSizes.xMedium,
-                      color: context.appColors.gold,
-                    ),
-                    Text(
-                      store.averageRatingLabel,
-                      style: AppText.label,
-                    ),
-                  ],
-                ),
+                if (store.hasRating)
+                  Row(
+                    spacing: AppSpacing.xxs,
+                    children: [
+                      Icon(
+                        AppIcons.star,
+                        size: AppIconSizes.xMedium,
+                        color: context.appColors.gold,
+                      ),
+                      Text(
+                        store.averageRatingLabel,
+                        style: AppText.label,
+                      ),
+                    ],
+                  ),
                 StatusPill(store: store),
               ],
             ),

--- a/lib/features/place_detail/view/widget/place_summary_card.dart
+++ b/lib/features/place_detail/view/widget/place_summary_card.dart
@@ -23,7 +23,8 @@ final class PlaceSummaryCard extends ConsumerWidget with AppProviderStateMixin {
       children: [
         _SummaryHeader(store: store, town: town),
         StatusPill(store: store),
-        if (store.isCommentEnabled) _SummaryRatingRow(store: store),
+        if (store.isCommentEnabled && store.hasRating)
+          _SummaryRatingRow(store: store),
         _SummaryActions(store: store, onCall: onCall, onComment: onComment),
       ],
     );

--- a/lib/features/sub_feature/forms/merchant_application/view/merchant_application_view.dart
+++ b/lib/features/sub_feature/forms/merchant_application/view/merchant_application_view.dart
@@ -64,77 +64,99 @@ final class _MerchantApplicationViewState
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: onPopInvoked,
-      child: IgnorePointer(
-        ignoring: state.isSubmitting,
-        child: Scaffold(
-          body: SafeArea(
-            child: Column(
-              children: [
-                MerchantStepIndicator(
-                  currentStep: state.currentStep.index,
-                  stepCount: MerchantApplicationState.stepCount,
-                  title: state.currentStep.titleKey.tr(),
-                  onClose: onClosePressed,
-                ),
-                Expanded(
-                  child: PageView(
-                    controller: pageController,
-                    physics: const NeverScrollableScrollPhysics(),
-                    children: [
-                      _MerchantCompanyStep(
-                        formKey: companyFormKey,
-                        nameController: placeNameController,
-                        descriptionController: placeDescriptionController,
-                      ),
-                      _MerchantMediaStep(
-                        formKey: mediaFormKey,
-                        addressController: addressController,
-                        openTimeController: openTimeController,
-                        closeTimeController: closeTimeController,
-                      ),
-                      _MerchantOwnerStep(
-                        formKey: ownerFormKey,
-                        nameController: placeOwnerNameController,
-                        phoneController: phoneNumberController,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-          bottomNavigationBar: SafeArea(
-            child: Padding(
-              padding: const PagePadding.defaultPadding(),
-              child: IntrinsicHeight(
-                child: Row(
+      child: Stack(
+        children: [
+          IgnorePointer(
+            ignoring: state.isSubmitting,
+            child: Scaffold(
+              body: SafeArea(
+                child: Column(
                   children: [
-                    if (!state.isFirstStep) ...[
-                      Expanded(
-                        child: GeneralButtonV2.active(
-                          label: LocaleKeys.merchantApplication_back.tr(),
-                          isBorderless: true,
-                          action: onBackPressed,
-                        ),
-                      ),
-                      const SizedBox(width: WidgetSizes.spacingM),
-                    ],
+                    MerchantStepIndicator(
+                      currentStep: state.currentStep.index,
+                      stepCount: MerchantApplicationState.stepCount,
+                      title: state.currentStep.titleKey.tr(),
+                      onClose: onClosePressed,
+                    ),
                     Expanded(
-                      flex: 2,
-                      child: GeneralButtonV2.active(
-                        label: state.isLastStep
-                            ? LocaleKeys.merchantApplication_submit.tr()
-                            : LocaleKeys.merchantApplication_next.tr(),
-                        action: onNextPressed,
+                      child: PageView(
+                        controller: pageController,
+                        physics: const NeverScrollableScrollPhysics(),
+                        children: [
+                          _MerchantCompanyStep(
+                            formKey: companyFormKey,
+                            nameController: placeNameController,
+                            descriptionController: placeDescriptionController,
+                          ),
+                          _MerchantMediaStep(
+                            formKey: mediaFormKey,
+                            addressController: addressController,
+                            openTimeController: openTimeController,
+                            closeTimeController: closeTimeController,
+                          ),
+                          _MerchantOwnerStep(
+                            formKey: ownerFormKey,
+                            nameController: placeOwnerNameController,
+                            phoneController: phoneNumberController,
+                          ),
+                        ],
                       ),
                     ),
                   ],
                 ),
-              ).ext.toDisabled(disable: state.isSubmitting, opacity: 0.5),
+              ),
+              bottomNavigationBar: SafeArea(
+                child: Padding(
+                  padding: const PagePadding.defaultPadding(),
+                  child: IntrinsicHeight(
+                    child: Row(
+                      children: [
+                        if (!state.isFirstStep) ...[
+                          Expanded(
+                            child: GeneralButtonV2.active(
+                              label: LocaleKeys.merchantApplication_back.tr(),
+                              isBorderless: true,
+                              action: onBackPressed,
+                            ),
+                          ),
+                          const SizedBox(width: WidgetSizes.spacingM),
+                        ],
+                        Expanded(
+                          flex: 2,
+                          child: GeneralButtonV2.active(
+                            label: state.isLastStep
+                                ? LocaleKeys.merchantApplication_submit.tr()
+                                : LocaleKeys.merchantApplication_next.tr(),
+                            action: onNextPressed,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ).ext.toDisabled(disable: state.isSubmitting, opacity: 0.5),
+                ),
+              ),
             ),
           ),
-        ),
+          if (state.isSubmitting)
+            const Positioned.fill(child: _MerchantSubmitOverlay()),
+        ],
       ),
+    );
+  }
+}
+
+final class _MerchantSubmitOverlay extends StatelessWidget {
+  const _MerchantSubmitOverlay();
+
+  static const double _scrimOpacity = 0.4;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: context.general.colorScheme.scrim.withValues(
+        alpha: _scrimOpacity,
+      ),
+      child: const Center(child: CircularProgressIndicator()),
     );
   }
 }

--- a/lib/product/navigation/app_router.dart
+++ b/lib/product/navigation/app_router.dart
@@ -11,6 +11,7 @@ import 'package:lifeclient/features/community/group_detail/group_detail_view.dar
 import 'package:lifeclient/features/details/view/event_detail_view.dart';
 import 'package:lifeclient/features/details/view/news_detail_view.dart';
 import 'package:lifeclient/features/main/event/view/event_view.dart';
+import 'package:lifeclient/features/main/history/history_view.dart';
 import 'package:lifeclient/features/main/news_jobs/view/news_jobs_view.dart';
 import 'package:lifeclient/features/main/profile/view/edit/edit_profile_view.dart';
 import 'package:lifeclient/features/main/settings/view/settings_view.dart';
@@ -75,6 +76,7 @@ final class SplashRoute extends GoRouteData with $SplashRoute {
     SavedNewsRoute.route,
     SpecialAgencyRoute.route,
     AdvertisementsRoute.route,
+    MemoriesRoute.route,
     PlaceDetailRoute.route,
     NewsJobsRoute.route,
     FilterRoute.route,
@@ -334,6 +336,19 @@ final class AdvertisementsRoute extends GoRouteData with $AdvertisementsRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const AdvertisementBoardView();
+}
+
+final class MemoriesRoute extends GoRouteData with $MemoriesRoute {
+  const MemoriesRoute();
+
+  static const route = TypedGoRoute<MemoriesRoute>(
+    path: 'memories',
+    name: 'Memories',
+  );
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const HistoryView();
 }
 
 final class ChainStoresRoute extends GoRouteData with $ChainStoresRoute {

--- a/lib/product/package/photo_picker/photo_picker_manager.dart
+++ b/lib/product/package/photo_picker/photo_picker_manager.dart
@@ -41,6 +41,7 @@ final class PhotoPickerManager {
     } on PlatformException catch (e) {
       await _handlePickerError(e.code);
     }
+    if (type == PhotoPickType.camera) mediaFile ??= await _retrieveLostFile();
     if (mediaFile == null) return null;
 
     final croppedFile = await ImageCropper().cropImage(
@@ -68,6 +69,18 @@ final class PhotoPickerManager {
     return latestFile;
   }
 
+  Future<XFile?> _retrieveLostFile() async {
+    if (!Platform.isAndroid) return null;
+    final response = await _picker.retrieveLostData();
+    if (response.isEmpty) return null;
+    final exception = response.exception;
+    if (exception != null) {
+      await _handlePickerError(exception.code);
+      return null;
+    }
+    return response.file;
+  }
+
   Future<File> createFile(String path) async {
     final file = File(path);
     if (!file.existsSync()) {
@@ -79,7 +92,7 @@ final class PhotoPickerManager {
   Future<void> _handlePickerError(String message) async {
     final type = PlatformExceptionEnum.fromValue(message);
 
-    if (type == null) return;
+    if (type == null || !context.mounted) return;
 
     /// now only support access denied
     final response = await ApproveDialog.showWithKey(

--- a/lib/product/utility/extension/store_etension.dart
+++ b/lib/product/utility/extension/store_etension.dart
@@ -22,7 +22,8 @@ extension StoreModelExtension on StoreModel {
   bool get hasMap => hasAddress && latLong != null;
 
   bool get hasContactInfo => hasPhone || hasAddress || hasMap;
- 
+
+  bool get hasRating => ratingCount > 0;
 
   static Map<String, Object?> updateFields({
     String? name,

--- a/lib/product/widget/card/general_place_card.dart
+++ b/lib/product/widget/card/general_place_card.dart
@@ -209,7 +209,7 @@ class _Body extends ConsumerWidget with AppProviderStateMixin {
           const EmptyBox.xxSmallHeight(),
           Row(
             children: [
-              if (model.isCommentEnabled) ...[
+              if (model.isCommentEnabled && model.hasRating) ...[
                 PlaceRatingLabel(
                   rating: model.averageRatingLabel,
                   reviewCount: model.ratingCount,

--- a/lib/product/widget/card/place/general_place_grid_card.dart
+++ b/lib/product/widget/card/place/general_place_grid_card.dart
@@ -205,7 +205,7 @@ class _GridBody extends ConsumerWidget with AppProviderStateMixin {
               ),
             ],
           ),
-          if (model.isCommentEnabled) ...[
+          if (model.isCommentEnabled && model.hasRating) ...[
             const EmptyBox.xSmallHeight(),
             PlaceRatingLabel(
               rating: model.averageRatingLabel,

--- a/lib/product/widget/sheet/general_media_sheet.dart
+++ b/lib/product/widget/sheet/general_media_sheet.dart
@@ -18,12 +18,14 @@ final class GeneralMediaSheet extends StatelessWidget {
   const GeneralMediaSheet({super.key});
 
   static Future<File?> open(BuildContext context) async {
-    return showModalBottomSheet<File?>(
+    final type = await showModalBottomSheet<PhotoPickType>(
       context: context,
       builder: (context) {
         return const GeneralMediaSheet();
       },
     );
+    if (type == null || !context.mounted) return null;
+    return PhotoPickerManager(context: context).pickPhoto(type: type);
   }
 
   @override
@@ -37,26 +39,12 @@ final class GeneralMediaSheet extends StatelessWidget {
             ListTile(
               leading: const Icon(AppIcons.camera),
               title: const Text(LocaleKeys.component_picker_camera).tr(),
-              onTap: () async {
-                final file = await PhotoPickerManager(context: context)
-                    .pickPhoto(type: PhotoPickType.camera);
-
-                if (file == null) return;
-                if (!context.mounted) return;
-                await context.route.pop(file);
-              },
+              onTap: () => context.route.pop(PhotoPickType.camera),
             ),
             ListTile(
               leading: const Icon(AppIcons.gallery),
               title: const Text(LocaleKeys.component_picker_gallery).tr(),
-              onTap: () async {
-                final file = await PhotoPickerManager(context: context)
-                    .pickPhoto(type: PhotoPickType.gallery);
-
-                if (file == null) return;
-                if (!context.mounted) return;
-                await context.route.pop(file);
-              },
+              onTap: () => context.route.pop(PhotoPickType.gallery),
             ),
           ],
         ),

--- a/lib/sub_feature/main_tab/widget/discover_tab_view.dart
+++ b/lib/sub_feature/main_tab/widget/discover_tab_view.dart
@@ -55,6 +55,14 @@ final class DiscoverTabView extends StatelessWidget {
                   LocaleKeys.navigationTabs_exploreMenu_linksDescription,
               destination: () => const UsefulLinksRoute().go(context),
             ),
+            _DiscoverTabItem(
+              icon: AppIcons.photoLibrary,
+              iconBackgroundColor: context.appColors.gold,
+              itemLabel: LocaleKeys.navigationTabs_memories,
+              descriptionLabel:
+                  LocaleKeys.navigationTabs_exploreMenu_memoriesDescription,
+              destination: () => const MemoriesRoute().go(context),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
Re-lands #480. That PR was merged, but into `fix/#481` instead of `main` — its base branch was never retargeted after #482 went in, so none of these four fixes ever reached `main`. The issues were closed by its `Closes` lines even though the code did not ship. Same four commits, now rebased onto current `main`.

Closes #476
Closes #477
Closes #478
Closes #479

The only rebase conflict was `app_router.dart`, where #484 added `AdvertisementsRoute` in the same place this branch adds `MemoriesRoute`. Both routes are kept.


## #476 — A place always showed a 0.0 rating

**What was wrong.** `StoreModel.averageRating` is `ratingSum / ratingCount`, and it returns `0` when nothing has been voted on yet. Every rating surface rendered that unconditionally, so a place with no reviews showed a filled gold star next to a literal `0.0`. That reads as "rated badly", not "not rated yet" — and since ratings only just shipped, essentially every place looked like it had the worst possible score.

**What changed.** `StoreModelExtension.hasRating` (`ratingCount > 0`) now gates every surface that renders a score:

| Surface | Before | After |
| --- | --- | --- |
| Place detail summary row | `⭐ 0.0 · 0 reviews` | row is not rendered |
| Place list card | `⭐ 0.0 (0)` | rating omitted, distance still shown |
| Place grid card | `⭐ 0.0 (0)` | rating omitted |
| Merchant panel header | `⭐ 0.0` | star row omitted |
| Merchant dashboard stat card | `0` | `—` |

The dashboard is the one place that keeps a value: it is a fixed three-stat grid (views / rating / reviews), so hiding one cell would leave a hole. It renders the new `merchantPanel.dashboard.emptyValue` key instead.

The comment call-to-action is untouched — a place with no reviews still invites you to write the first one.

## #477 — The merchant application froze after taking a photo

**What was wrong.** `GeneralMediaSheet` launched the camera from inside its own `builder` context:

```dart
onTap: () async {
  final file = await PhotoPickerManager(context: context).pickPhoto(type: PhotoPickType.camera);
  if (file == null) return;
  if (!context.mounted) return;   // <- this context belongs to the sheet
  await context.route.pop(file);
}
```

Opening the camera sends the app to the background. On return that context can already be deactivated, so `context.mounted` is `false`, the early return fires, the sheet never pops and no file is delivered. From the user's side the screen simply stops responding. Picking from the gallery never backgrounds the app, which is exactly why only the camera path failed.

**What changed.** The sheet no longer does the work. It returns the chosen `PhotoPickType` and pops immediately; the pick then runs on the **caller's** context, which outlives the sheet:

```dart
static Future<File?> open(BuildContext context) async {
  final type = await showModalBottomSheet<PhotoPickType>(...);
  if (type == null || !context.mounted) return null;
  return PhotoPickerManager(context: context).pickPhoto(type: type);
}
```

The public signature is unchanged (`Future<File?>`), so none of the four call sites — merchant application media step, merchant module form sheet, merchant store edit, dotted photo add — needed to change.

Two hardening fixes in `PhotoPickerManager` alongside it:

- **Android lost-data recovery.** Android can destroy the activity while the camera is open; the photo is then only retrievable from `ImagePicker.retrieveLostData()`. That recovery now runs — but **only on the camera path**, so a cancelled gallery pick can never surface a stale photo from an earlier killed session.
- `retrieveLostData()`'s `response.exception` is routed through `_handlePickerError` instead of being dropped, and `_handlePickerError` checks `context.mounted` before showing the permission dialog (it runs after an await).

## #478 — No loading state on the last step of the merchant application

**What was wrong.** Submitting uploads the photos and writes the application, which takes seconds. The view had the `isSubmitting` flag and used it — but only to dim the button row to 50% opacity and swallow taps. Nothing moved, nothing spun, and then the app suddenly navigated away.

**What changed.** While `isSubmitting` is set, a scrim (`colorScheme.scrim` at 40%) with a centred progress indicator covers the page. The existing `IgnorePointer` still blocks input underneath.

## #479 — The memories page disappeared from Discover

**What was wrong.** The Discover redesign shipped four cards (institutions, container bazaars, tourist spots, useful links) and dropped the memories entry. `HistoryView` was never deleted — it just lost its tab slot and was never given a route, so the whole feature became unreachable from the app. Users who had it in the previous version simply could not find their memories any more.

**What changed.**

- `MemoriesRoute` (`/main/memories`) registered under `MainTabRoute.routes`, entered with `const MemoriesRoute().go(context)` — same shape as the `SpecialAgencyRoute` / `UsefulLinksRoute` siblings.
- A fifth Discover card (photo-library icon, gold accent) pointing at it.
- `navigationTabs.exploreMenu.memoriesDescription` added to both locales.
- `HistoryView` now carries a `DiscoverSectionAppBar`, so the pushed page has a title and a back button like the other Discover sections.
- Its floating buttons drop the `AppIconSizes.xLarge * 2.5` bottom offset. That offset existed to clear the bottom tab bar; as a pushed page there is no tab bar to clear.

---

## Notes for review

- `HistoryView` still lives at `lib/features/main/history/` and is named after "history" while the route, the card and the locale keys all say "memories". Renaming the feature is a separate cleanup, not done here.
- The submit overlay is a private widget in the merchant application view. It is generic enough to belong in `lib/product/widget/`, but it currently has a single caller, so it was left local rather than promoted on speculation.

## Verification

- `dart analyze lib` — no issues
- `dart format --set-exit-if-changed` on all touched files — clean
- Architecture pass against CLAUDE.md — no blockers

## Still needs manual testing

- **#477 on a real Android device.** The freeze depends on the OS backgrounding the app during capture, which simulators do not reproduce.
- **#478 with a real submission**, so the upload actually takes long enough to see the overlay.
- **#476** on a place that does have reviews, to confirm the rating still appears where it should.
